### PR TITLE
Cargo docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,6 @@ jobs:
           google-chrome --version
       - run: ~/anon/scripts/init.sh
       - run: source ~/.cargo/env && ~/anon/scripts/test.sh
-      - run: source ~/.cargo/env && ~/anon/scripts/build.sh
+      - run: source ~/.cargo/env && ~/anon/scripts/build_benchmarks.sh
 orbs:
   browser-tools: circleci/browser-tools@1.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/node:15.6.0
+      - image: cimg/rust:1.50-browsers
         environment:
           DEBUG_BUILD: true
           DEBIAN_FRONTEND: noninteractive
@@ -10,16 +10,15 @@ jobs:
     working_directory: ~/anon
 
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
-      - run:
-          command: |
-            google-chrome --version
-            chromedriver --version
-          name: Check install
+      - browser-tools/install-browser-tools
       - checkout
+      - run: |
+          cargo --version
+          node --version
+          java --version
+          google-chrome --version
       - run: ~/anon/scripts/init.sh
       - run: source ~/.cargo/env && ~/anon/scripts/test.sh
       - run: source ~/.cargo/env && ~/anon/scripts/build.sh
 orbs:
-  browser-tools: circleci/browser-tools@1.1.1
+  browser-tools: circleci/browser-tools@1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 [[package]]
 name = "curve25519-gadgets"
 version = "2.0.0"
-source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=main#217de1a3692c7e9bec768a2b0ba38018972d1601"
+source = "git+https://github.com/webb-tools/bulletproof-gadgets?rev=217de1a#217de1a3692c7e9bec768a2b0ba38018972d1601"
 dependencies = [
  "bencher",
  "bulletproofs",

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -36,7 +36,7 @@ default-features = false
 features = ["u64_backend", "alloc"]
 
 [dependencies.curve25519-gadgets]
-branch = "main"
+rev = "217de1a"
 version = "2.0.0"
 git = "https://github.com/webb-tools/bulletproof-gadgets"
 default-features = false

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -1,13 +1,81 @@
+// A runtime module Groups with necessary imports
+
+// Feel free to remove or edit this file as needed.
+// If you change the name of this file, make sure to update its references in
+// runtime/src/lib.rs If you remove this file, you can remove those references
+
+// For more guidance on Substrate modules, see the example module
+// https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs
+
+//! # Merkle Pallet
+//!
+//! The Merkle pallet provides functionality for making and managing the Merkle
+//! trees.
+//!
+//! - [`Config`]
+//! - [`Call`]
+//! - [`Pallet`]
+//!
+//! ## Overview
+//!
+//! The Merkle pallet provides functions for:
+//!
+//! - Creating merkle trees.
+//! - Adding the manager and setting whether the manager is required.
+//! - Adding leaf data to the Merkle tree.
+//! - Adding nullifiers to the storage.
+//! - Managing start/stop flags.
+//! - Caching merkle tree states.
+//! - Verifying regular and zero-knowledge membership proofs
+//!
+//! ### Terminology
+//!
+//! - **Membership proof in zero-knowladge:** Proving that leaf is inside the
+//!   tree without revealing which leaf you are proving over.
+//!
+//! - **Proof of creation in zero-knowladge:** TBA
+//!
+//! - **Nullifier:** Each leaf is made with an arithmetic circuit which includes
+//!   hashing several values. Nullifier is a part of this leaf circuit and is
+//!   revealed when proving membership in zero-knowladge.
+//!
+//! ### Implementations
+//!
+//! The merkle pallet provides implementations for following traits:
+//!
+//! - [`Group`](pallet_merkle::group_trait::Group) Functions for crerating and
+//!   managing the group.
+//!
+//! ## Interface
+//!
+//! ### Dispatchable functions
+//!
+//! - `create_group` - Create merkle tree and their respective manager account.
+//! - `set_manager_required` - Set whether manager is required to add members
+//!   and nullifiers.
+//! - `set_manager` - Set manager account id. Can only be called by the root or
+//!   the current manager.
+//! - `set_stopped` - Sets stopped storage flag. This flag by itself doesn't do
+//!   anything. It's up to a higher level pallets to make an appropriate use of
+//!   it. Can only be called by the root or the manager;
+//! - `add_members` Adds an array of leaves to the tree. Can only be called by
+//!   the manager if the manager is required.
+//! - `verify` - Verifies the membership proof.
+//!
+//! ## Usage
+//!
+//! The following examples show how to use the Merkle pallet in your custom
+//! pallet.
+//!
+//! ```
+//! use pallet_merkle::group_trait::Group;
+//! pub trait Config: frame_system::Config + pallet_merkle::Config {
+//! 	type Group: Group<Self::AccountId, Self::BlockNumber, Self::GroupId>;
+//! }
+//! ```
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// A runtime module Groups with necessary imports
-
-/// Feel free to remove or edit this file as needed.
-/// If you change the name of this file, make sure to update its references in
-/// runtime/src/lib.rs If you remove this file, you can remove those references
-
-/// For more guidance on Substrate modules, see the example module
-/// https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs
 pub mod utils;
 
 #[cfg(test)]

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -299,6 +299,18 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		/// Creates a new group and sets a new manager for that group. The
+		/// initial manager is the sender. Also increments the mixer id counter
+		/// in the storage. If _depth is not provided, max tree depth is
+		/// assumed.
+		///
+		/// # <weight>
+		/// - Dependent on arguments: _depth
+		///
+		/// - Base weight: 7_618_000
+		/// - DB weights: 1 read, 3 writes
+		/// - Additional weights: 151_000 * _depth
+		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::create_group(_depth.map_or(T::MaxTreeDepth::get() as u32, |x| x as u32)))]
 		pub fn create_group(origin: OriginFor<T>, r_is_mgr: bool, _depth: Option<u8>) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
@@ -310,6 +322,17 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		/// Sets if manager is required for specific actions like adding
+		/// nullifiers or leaves into the tree.
+		///
+		/// Can only be called by the root or the current manager.
+		///
+		/// # <weight>
+		/// - Independend of the arguments.
+		///
+		/// - Base weight: 8_000_000
+		/// - DB weight: 1 read, 1 write
+		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::set_manager_required())]
 		pub fn set_manager_required(
 			origin: OriginFor<T>,
@@ -322,6 +345,16 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		/// Sets manager account id.
+		///
+		/// Can only be called by the root or the current manager.
+		///
+		/// # <weight>
+		/// - Independent of the arguments.
+		///
+		/// - Base weight: 8_000_000
+		/// - DB weight: 1 read, 1 write
+		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::set_manager())]
 		pub fn set_manager(
 			origin: OriginFor<T>,
@@ -340,6 +373,16 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		/// Set stopped flag inside the storage.
+		///
+		/// Can only be called by the root or the current manager.
+		///
+		/// # <weight>
+		/// - Independent of the arguments.
+		///
+		/// - Base weight: 7_000_000
+		/// - DB weight: 1 read, 1 write
+		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::set_stopped())]
 		pub fn set_stopped(origin: OriginFor<T>, group_id: T::GroupId, stopped: bool) -> DispatchResultWithPostInfo {
 			let manager_data = Managers::<T>::get(group_id)
@@ -350,6 +393,16 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		/// Adds an array of leaf data into the tree and adds calculated root to
+		/// the cache.
+		///
+		/// Can only be called by the manager if manager is set.
+		///
+		/// # <weight>
+		/// - Base weight: 305_389_489_000
+		/// - DB weight: 3 reads, 2 writes
+		/// - Additional weights: 63_659_275_000 * members.len()
+		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::add_members(members.len() as u32))]
 		pub fn add_members(
 			origin: OriginFor<T>,
@@ -365,6 +418,14 @@ pub mod pallet {
 		/// not need to be used directly as extrinsics. Rather, higher-order
 		/// modules should use the module functions to verify and execute
 		/// further logic.
+		///
+		/// Verifies the membership proof.
+		///
+		/// # <weight>
+		/// - Base weight: 310_970_311_000
+		/// - DB weight: 1 read
+		/// - Additional weights: 3_666_683_000 * path.len()
+		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::verify_path(path.len() as u32))]
 		pub fn verify(
 			origin: OriginFor<T>,

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! The merkle pallet provides implementations for following traits:
 //!
-//! - [`Group`](pallet_merkle::group_trait::Group) Functions for crerating and
+//! - [`Group`](pallet_merkle::traits::Group) Functions for crerating and
 //!   managing the group.
 //!
 //! ## Interface
@@ -68,7 +68,7 @@
 //! pallet.
 //!
 //! ```
-//! use pallet_merkle::group_trait::Group;
+//! use pallet_merkle::traits::Group;
 //! pub trait Config: frame_system::Config + pallet_merkle::Config {
 //! 	type Group: Group<Self::AccountId, Self::BlockNumber, Self::GroupId>;
 //! }
@@ -89,7 +89,6 @@ pub mod tests;
 mod benchmarking;
 pub mod weights;
 
-pub use crate::traits::Group;
 use bulletproofs::{
 	r1cs::{R1CSProof, Verifier},
 	BulletproofGens, PedersenGens,
@@ -109,6 +108,7 @@ use curve25519_gadgets::{
 use frame_support::{dispatch, ensure, traits::Get, weights::Weight, Parameter};
 use frame_system::ensure_signed;
 use sp_std::prelude::*;
+pub use traits::Group;
 
 use merlin::Transcript;
 use rand_core::OsRng;

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -304,13 +304,12 @@ pub mod pallet {
 		/// in the storage. If _depth is not provided, max tree depth is
 		/// assumed.
 		///
-		/// # <weight>
+		/// Weights:
 		/// - Dependent on arguments: _depth
 		///
 		/// - Base weight: 7_618_000
 		/// - DB weights: 1 read, 3 writes
 		/// - Additional weights: 151_000 * _depth
-		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::create_group(_depth.map_or(T::MaxTreeDepth::get() as u32, |x| x as u32)))]
 		pub fn create_group(origin: OriginFor<T>, r_is_mgr: bool, _depth: Option<u8>) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
@@ -327,12 +326,11 @@ pub mod pallet {
 		///
 		/// Can only be called by the root or the current manager.
 		///
-		/// # <weight>
+		/// Weights:
 		/// - Independend of the arguments.
 		///
 		/// - Base weight: 8_000_000
-		/// - DB weight: 1 read, 1 write
-		/// # <weight>
+		/// - DB weights: 1 read, 1 write
 		#[pallet::weight(<T as Config>::WeightInfo::set_manager_required())]
 		pub fn set_manager_required(
 			origin: OriginFor<T>,
@@ -349,12 +347,11 @@ pub mod pallet {
 		///
 		/// Can only be called by the root or the current manager.
 		///
-		/// # <weight>
+		/// Weights:
 		/// - Independent of the arguments.
 		///
 		/// - Base weight: 8_000_000
-		/// - DB weight: 1 read, 1 write
-		/// # <weight>
+		/// - DB weights: 1 read, 1 write
 		#[pallet::weight(<T as Config>::WeightInfo::set_manager())]
 		pub fn set_manager(
 			origin: OriginFor<T>,
@@ -377,12 +374,11 @@ pub mod pallet {
 		///
 		/// Can only be called by the root or the current manager.
 		///
-		/// # <weight>
+		/// Weights:
 		/// - Independent of the arguments.
 		///
 		/// - Base weight: 7_000_000
-		/// - DB weight: 1 read, 1 write
-		/// # <weight>
+		/// - DB weights: 1 read, 1 write
 		#[pallet::weight(<T as Config>::WeightInfo::set_stopped())]
 		pub fn set_stopped(origin: OriginFor<T>, group_id: T::GroupId, stopped: bool) -> DispatchResultWithPostInfo {
 			let manager_data = Managers::<T>::get(group_id)
@@ -398,11 +394,12 @@ pub mod pallet {
 		///
 		/// Can only be called by the manager if manager is set.
 		///
-		/// # <weight>
+		/// Weights:
+		/// - Dependent on argument: `members`
+		///
 		/// - Base weight: 305_389_489_000
-		/// - DB weight: 3 reads, 2 writes
+		/// - DB weights: 3 reads, 2 writes
 		/// - Additional weights: 63_659_275_000 * members.len()
-		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::add_members(members.len() as u32))]
 		pub fn add_members(
 			origin: OriginFor<T>,
@@ -421,11 +418,11 @@ pub mod pallet {
 		///
 		/// Verifies the membership proof.
 		///
-		/// # <weight>
+		/// Weights:
+		/// - Dependent on the argument: `path`
 		/// - Base weight: 310_970_311_000
-		/// - DB weight: 1 read
+		/// - DB weights: 1 read
 		/// - Additional weights: 3_666_683_000 * path.len()
-		/// # <weight>
 		#[pallet::weight(<T as Config>::WeightInfo::verify_path(path.len() as u32))]
 		pub fn verify(
 			origin: OriginFor<T>,

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -1,3 +1,5 @@
+//! All the traits exposed to be used in other custom pallets
+
 use crate::utils::keys::{Commitment, ScalarData};
 use bulletproofs::PedersenGens;
 pub use frame_support::dispatch;

--- a/pallets/merkle/src/utils/keys.rs
+++ b/pallets/merkle/src/utils/keys.rs
@@ -1,3 +1,5 @@
+//! Type definitions used in merkle pallet
+
 use sha2::Sha512;
 use sp_std::prelude::*;
 

--- a/pallets/merkle/src/utils/mod.rs
+++ b/pallets/merkle/src/utils/mod.rs
@@ -1,3 +1,5 @@
+//! Utility functions and data type definitions
+
 pub mod hasher;
 pub mod keys;
 pub mod permissions;

--- a/pallets/merkle/src/utils/permissions.rs
+++ b/pallets/merkle/src/utils/permissions.rs
@@ -1,3 +1,5 @@
+//! Utility functions for authorizations and permissions
+
 use frame_system::RawOrigin;
 use sp_runtime::traits::BadOrigin;
 

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -22,7 +22,7 @@ merlin = { version = "2.0.0", default-features = false }
 frame-benchmarking = { default-features = false, version = "3.0.0", optional = true }
 
 [dependencies.curve25519-gadgets]
-branch = "main"
+rev = "217de1a"
 version = "2.0.0"
 git = "https://github.com/webb-tools/bulletproof-gadgets"
 default-features = false

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -40,6 +40,9 @@ use sp_runtime::{
 use sp_std::prelude::*;
 use weights::WeightInfo;
 
+pub use pallet::*;
+
+/// Implementation of Mixer pallet
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -315,8 +318,10 @@ pub mod pallet {
 	}
 }
 
+/// Type alias for the balances_pallet::Balance type
 pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
+/// Info about the mixer and it's leaf data
 #[derive(Encode, Decode, PartialEq)]
 pub struct MixerInfo<T: Config> {
 	pub minimum_deposit_length_for_reward: T::BlockNumber,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-02-20"
+channel = "nightly-2021-03-02"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,7 @@ SCRIPTDIR=$PWD
 
 # test each pallets tests
 for d in $(ls -d ./pallets/*/) ; do
-    cd "$SCRIPTDIR/$d" && WASM_BUILD_TOOLCHAIN=nightly-2020-12-31 cargo test --features runtime-benchmarks
+    cd "$SCRIPTDIR/$d" && cargo test --features runtime-benchmarks
 done
 
 # test wasm utils

--- a/wasm-utils/Cargo.toml
+++ b/wasm-utils/Cargo.toml
@@ -23,7 +23,7 @@ default-features = false
 features = ["yoloproofs", "std"]
 
 [dependencies.curve25519-gadgets]
-branch = "main"
+rev = "217de1a"
 version = "2.0.0"
 git = "https://github.com/webb-tools/bulletproof-gadgets"
 

--- a/wasm-utils/src/lib.rs
+++ b/wasm-utils/src/lib.rs
@@ -120,8 +120,8 @@ impl PoseidonHasher {
 
 	#[wasm_bindgen(constructor)]
 	pub fn with_options(opts: PoseidonHasherOptions) -> Self {
-		let full_rounds_beginning = opts.full_rounds_beginning.unwrap_or(3);
-		let full_rounds_end = opts.full_rounds_end.unwrap_or(3);
+		let full_rounds_beginning = opts.full_rounds_beginning.unwrap_or(4);
+		let full_rounds_end = opts.full_rounds_end.unwrap_or(4);
 		let partial_rounds = opts.partial_rounds.unwrap_or(57);
 
 		// default pedersen genrators


### PR DESCRIPTION
It Will be published on cretes.io after the review.

To generate the docs navigate to: `./pallets/[pallet_name]` and run `cargo doc --open --no-deps`