### PR TITLE
Bulletproofs Update - Storing generators in runtime storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
  "parity-scale-codec 1.3.7",
  "rand_core 0.5.1",
  "sp-std 2.0.1",
- "webb-bulletproofs",
+ "webb-bulletproofs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4475,7 +4475,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 3.0.0",
- "webb-bulletproofs",
+ "webb-bulletproofs 2.0.2 (git+https://github.com/webb-tools/bulletproofs?branch=pub-bp-gens)",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 3.0.0",
- "webb-bulletproofs",
+ "webb-bulletproofs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-currencies",
  "webb-tokens",
  "webb-traits",
@@ -9142,8 +9142,7 @@ dependencies = [
 [[package]]
 name = "webb-bulletproofs"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8db2fdcf907c6353e0575df8c6ab919eed5647ad974fa28a78150f3884419a"
+source = "git+https://github.com/webb-tools/bulletproofs?branch=pub-bp-gens#b52d42ce66b1e65f8e62ed101307b7c543eb5773"
 dependencies = [
  "byteorder",
  "clear_on_drop",
@@ -9158,6 +9157,23 @@ dependencies = [
  "sp-std 2.0.1",
  "subtle 2.4.0",
  "thiserror",
+]
+
+[[package]]
+name = "webb-bulletproofs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8db2fdcf907c6353e0575df8c6ab919eed5647ad974fa28a78150f3884419a"
+dependencies = [
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek 3.1.0",
+ "digest 0.9.0",
+ "merlin",
+ "rand_core 0.5.1",
+ "sha3 0.9.1",
+ "sp-std 2.0.1",
+ "subtle 2.4.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.25.2",
+ "object 0.25.3",
  "rustc-demangle",
 ]
 
@@ -630,9 +630,8 @@ dependencies = [
 
 [[package]]
 name = "bulletproofs-gadgets"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f730544daa13f48320a9be1bf804dd3544193f20a4194901317fd3ec354861fb"
+version = "2.1.0"
+source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=bulletproofs-codec#4b4b2b50ea47fb1596f1b03bf39891868d11ebeb"
 dependencies = [
  "bencher",
  "curve25519-dalek 3.1.0",
@@ -640,7 +639,7 @@ dependencies = [
  "parity-scale-codec 1.3.7",
  "rand_core 0.5.1",
  "sp-std 2.0.1",
- "webb-bulletproofs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb-bulletproofs",
 ]
 
 [[package]]
@@ -2314,9 +2313,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+checksum = "f0fc1b9fa0e64ffb1aa5b95daa0f0f167734fd528b7c02eabc581d9d843649b1"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3123,9 +3122,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.96"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -4186,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "memchr",
 ]
@@ -4475,7 +4474,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 3.0.0",
- "webb-bulletproofs 2.0.2 (git+https://github.com/webb-tools/bulletproofs?branch=pub-bp-gens)",
+ "webb-bulletproofs",
 ]
 
 [[package]]
@@ -4514,7 +4513,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 3.0.0",
- "webb-bulletproofs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb-bulletproofs",
  "webb-currencies",
  "webb-tokens",
  "webb-traits",
@@ -8557,7 +8556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.3.23",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -9157,23 +9156,6 @@ dependencies = [
  "sp-std 2.0.1",
  "subtle 2.4.0",
  "thiserror",
-]
-
-[[package]]
-name = "webb-bulletproofs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8db2fdcf907c6353e0575df8c6ab919eed5647ad974fa28a78150f3884419a"
-dependencies = [
- "byteorder",
- "clear_on_drop",
- "curve25519-dalek 3.1.0",
- "digest 0.9.0",
- "merlin",
- "rand_core 0.5.1",
- "sha3 0.9.1",
- "sp-std 2.0.1",
- "subtle 2.4.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,12 +476,22 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+dependencies = [
+ "either",
+ "radium 0.3.0",
+]
+
+[[package]]
+name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.6.2",
  "tap",
  "wyz",
 ]
@@ -630,13 +640,16 @@ dependencies = [
 
 [[package]]
 name = "bulletproofs-gadgets"
-version = "2.1.0"
-source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=bulletproofs-codec#0edc084f37f17e392ec0023a562c17dc880d9788"
+version = "2.1.1"
+source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=bulletproofs-codec#72fada0df29027f91be7d4f867f9ee5bd402889d"
 dependencies = [
  "bencher",
  "curve25519-dalek 3.1.0",
+ "hex",
  "merlin",
+ "num-bigint 0.3.2",
  "parity-scale-codec 1.3.7",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "sp-std 2.0.1",
  "webb-bulletproofs",
@@ -4102,6 +4115,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4137,7 +4161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -4685,8 +4709,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
 dependencies = [
  "arrayvec 0.5.2",
+ "bitvec 0.17.4",
  "byte-slice-cast 0.3.5",
  "parity-scale-codec-derive 1.2.3",
+ "serde",
 ]
 
 [[package]]
@@ -4696,7 +4722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f518afaa5a47d0d6386229b0a6e01e86427291d643aa4cabb4992219f504f8"
 dependencies = [
  "arrayvec 0.7.1",
- "bitvec",
+ "bitvec 0.20.4",
  "byte-slice-cast 1.0.0",
  "parity-scale-codec-derive 2.1.0",
  "serde",
@@ -5297,6 +5323,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radium"
@@ -6016,7 +6048,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "log",
  "merlin",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-rational 0.2.4",
  "num-traits",
  "parity-scale-codec 2.1.1",
@@ -9142,8 +9174,8 @@ dependencies = [
 
 [[package]]
 name = "webb-bulletproofs"
-version = "2.0.2"
-source = "git+https://github.com/webb-tools/bulletproofs?branch=pub-bp-gens#b52d42ce66b1e65f8e62ed101307b7c543eb5773"
+version = "2.0.3"
+source = "git+https://github.com/webb-tools/bulletproofs#4897dfcf14c28fa11b91d6fc32912e21fae7f649"
 dependencies = [
  "byteorder",
  "clear_on_drop",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "bulletproofs-gadgets"
 version = "2.1.0"
-source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=bulletproofs-codec#4b4b2b50ea47fb1596f1b03bf39891868d11ebeb"
+source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=bulletproofs-codec#0edc084f37f17e392ec0023a562c17dc880d9788"
 dependencies = [
  "bencher",
  "curve25519-dalek 3.1.0",
@@ -4194,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 dependencies = [
  "parking_lot 0.11.1",
 ]
@@ -5064,14 +5064,14 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "polling"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
+checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "log",
- "wepoll-sys",
+ "wepoll-ffi",
  "winapi 0.3.9",
 ]
 
@@ -9355,10 +9355,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys"
-version = "3.0.1"
+name = "wepoll-ffi"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -4465,8 +4465,9 @@ dependencies = [
  "lazy_static",
  "merlin",
  "pallet-balances",
+ "pallet-randomness-collective-flip",
  "parity-scale-codec 2.1.1",
- "rand_core 0.5.1",
+ "rand_chacha 0.2.2",
  "serde",
  "sha2 0.9.5",
  "sp-api",
@@ -4507,6 +4508,7 @@ dependencies = [
  "merlin",
  "pallet-balances",
  "pallet-merkle",
+ "pallet-randomness-collective-flip",
  "parity-scale-codec 2.1.1",
  "serde",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,8 @@ dependencies = [
 [[package]]
 name = "bulletproofs-gadgets"
 version = "2.1.1"
-source = "git+https://github.com/webb-tools/bulletproof-gadgets?branch=bulletproofs-codec#72fada0df29027f91be7d4f867f9ee5bd402889d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94aea73d25b120dc50af0196f944e5df2e1e6aab93d8793e810b6b42c4d52b3e"
 dependencies = [
  "bencher",
  "curve25519-dalek 3.1.0",
@@ -9175,7 +9176,8 @@ dependencies = [
 [[package]]
 name = "webb-bulletproofs"
 version = "2.0.3"
-source = "git+https://github.com/webb-tools/bulletproofs#4897dfcf14c28fa11b91d6fc32912e21fae7f649"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab7788f5651d9df9225919e5a487ac1f522cc57e5c58ff03911eeec597259f6"
 dependencies = [
  "byteorder",
  "clear_on_drop",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -164,8 +164,6 @@ fn testnet_genesis(
 			key: root_key,
 		},
 		pallet_ethereum: Default::default(),
-		pallet_evm: EVMConfig {
-			accounts: evm_accounts,
-		},
+		pallet_evm: EVMConfig { accounts: evm_accounts },
 	}
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -179,20 +179,14 @@ where
 		)));
 	}
 
-	io.extend_with(
-		NetApiServer::to_delegate(NetApi::new(
-			client.clone(),
-			network.clone(),
-			// Whether to format the `peer_count` response as Hex (default) or not.
-			true,
-		))
-	);
+	io.extend_with(NetApiServer::to_delegate(NetApi::new(
+		client.clone(),
+		network.clone(),
+		// Whether to format the `peer_count` response as Hex (default) or not.
+		true,
+	)));
 
-	io.extend_with(
-		Web3ApiServer::to_delegate(Web3Api::new(
-			client.clone(),
-		))
-	);
+	io.extend_with(Web3ApiServer::to_delegate(Web3Api::new(client.clone())));
 
 	io.extend_with(EthPubSubApiServer::to_delegate(EthPubSubApi::new(
 		pool.clone(),

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -18,7 +18,9 @@ sp-std = { default-features = false, version = "3.0.0", git = "https://github.co
 sp-runtime = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
 merlin = { version = "2.0.0", default-features = false }
 sha2 = { version = "0.9.1", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
+
+rand_chacha = { version = "0.2", default-features = false }
+
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-api = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
 sp-io = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
@@ -46,6 +48,8 @@ branch = "bulletproofs-codec"
 
 [dev-dependencies]
 sp-core = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
+pallet-randomness-collective-flip = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
+
 
 [features]
 default = ["std"]

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -34,6 +34,8 @@ features = ["u64_backend", "alloc"]
 version = "2.0.0"
 package = "webb-bulletproofs"
 default-features = false
+git = "https://github.com/webb-tools/bulletproofs"
+branch = "pub-bp-gens"
 features = ["yoloproofs"]
 
 [dependencies.bulletproofs-gadgets]

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -33,15 +33,14 @@ default-features = false
 features = ["u64_backend", "alloc"]
 
 [dependencies.bulletproofs]
-version = "2.0.0"
+version = "2.0.3"
 package = "webb-bulletproofs"
 default-features = false
 git = "https://github.com/webb-tools/bulletproofs"
-branch = "pub-bp-gens"
 features = ["yoloproofs"]
 
 [dependencies.bulletproofs-gadgets]
-version = "2.0.0"
+version = "2.1.1"
 default-features = false
 git = "https://github.com/webb-tools/bulletproof-gadgets"
 branch = "bulletproofs-codec"
@@ -61,6 +60,7 @@ std = [
     "balances/std",
     "codec/std",
     "bulletproofs/std",
+    "bulletproofs-gadgets/std",
     "frame-support/std",
     "frame-system/std",
     "frame-benchmarking/std",

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -36,14 +36,11 @@ features = ["u64_backend", "alloc"]
 version = "2.0.3"
 package = "webb-bulletproofs"
 default-features = false
-git = "https://github.com/webb-tools/bulletproofs"
 features = ["yoloproofs"]
 
 [dependencies.bulletproofs-gadgets]
 version = "2.1.1"
 default-features = false
-git = "https://github.com/webb-tools/bulletproof-gadgets"
-branch = "bulletproofs-codec"
 
 [dev-dependencies]
 sp-core = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -41,6 +41,8 @@ features = ["yoloproofs"]
 [dependencies.bulletproofs-gadgets]
 version = "2.0.0"
 default-features = false
+git = "https://github.com/webb-tools/bulletproof-gadgets"
+branch = "bulletproofs-codec"
 
 [dev-dependencies]
 sp-core = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -322,11 +322,7 @@ pub mod pallet {
 		/// - DB weights: 1 read, 3 writes
 		/// - Additional weights: 151_000 * _depth
 		#[pallet::weight(<T as Config>::WeightInfo::create_tree(_depth.map_or(T::MaxTreeDepth::get() as u32, |x| x as u32)))]
-		pub fn create_tree(
-			origin: OriginFor<T>,
-			mgr_required: bool,
-			_depth: Option<u8>,
-		) -> DispatchResultWithPostInfo {
+		pub fn create_tree(origin: OriginFor<T>, mgr_required: bool, _depth: Option<u8>) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			let depth = match _depth {
 				Some(d) => d,

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -107,14 +107,17 @@ use bulletproofs_gadgets::{
 };
 use codec::{Decode, Encode, Input};
 use curve25519_dalek::scalar::Scalar;
-use frame_support::{dispatch, ensure, traits::Get, weights::Weight, Parameter};
+use frame_support::{
+	dispatch, ensure,
+	traits::{Get, Randomness},
+	weights::Weight,
+	Parameter,
+};
 use frame_system::ensure_signed;
-use frame_support::traits::Randomness;
 
 use merlin::Transcript;
 
-use rand_chacha::rand_core::SeedableRng;
-use rand_chacha::ChaChaRng;
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use sp_runtime::traits::{AtLeast32Bit, One};
 use sp_std::prelude::*;
 pub use traits::Tree;
@@ -155,7 +158,8 @@ pub mod pallet {
 		type MaxTreeDepth: Get<u8>;
 		/// The amount of blocks to cache roots over
 		type CacheBlockLength: Get<Self::BlockNumber>;
-		/// The generator used to supply randomness to contracts through `seal_random`.
+		/// The generator used to supply randomness to contracts through
+		/// `seal_random`.
 		type Randomness: Randomness<Self::Hash, Self::BlockNumber>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -105,7 +105,7 @@ use bulletproofs_gadgets::{
 	smt::gen_zero_tree,
 	utils::AllocatedScalar,
 };
-use codec::{Decode, Encode, Input};
+use codec::{Decode, Encode};
 use curve25519_dalek::scalar::Scalar;
 use frame_support::{
 	dispatch, ensure,

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -83,10 +83,10 @@ impl balances::Config for Test {
 impl Config for Test {
 	type CacheBlockLength = CacheBlockLength;
 	type Event = Event;
+	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
 	type WeightInfo = Weights<Self>;
-	type KeyId = u32;
 }
 
 pub type MerkleCall = pallet_merkle::Call<Test>;

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -24,6 +24,7 @@ construct_runtime!(
 	{
 		System: system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Randomness: pallet_randomness_collective_flip::{Pallet, Call, Storage},
 		MerkleTrees: pallet_merkle::{Pallet, Call, Storage, Event<T>},
 	}
 );
@@ -86,6 +87,7 @@ impl Config for Test {
 	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
+	type Randomness = Randomness;
 	type WeightInfo = Weights<Self>;
 }
 

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -86,6 +86,7 @@ impl Config for Test {
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
 	type WeightInfo = Weights<Self>;
+	type KeyId = u32;
 }
 
 pub type MerkleCall = pallet_merkle::Call<Test>;

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -86,8 +86,8 @@ impl Config for Test {
 	type Event = Event;
 	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
-	type TreeId = u32;
 	type Randomness = Randomness;
+	type TreeId = u32;
 	type WeightInfo = Weights<Self>;
 }
 

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -36,14 +36,14 @@ fn default_hasher(num_gens: usize) -> Poseidon {
 #[test]
 fn can_create_tree() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 	});
 }
 
 #[test]
 fn can_update_manager_when_required() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3)));
 
 		assert_ok!(MerkleTrees::set_manager(Origin::signed(1), 0, 2,));
 
@@ -55,7 +55,7 @@ fn can_update_manager_when_required() {
 #[test]
 fn can_update_manager_when_not_required() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 
 		assert_ok!(MerkleTrees::set_manager(Origin::signed(1), 0, 2,));
 
@@ -67,7 +67,7 @@ fn can_update_manager_when_not_required() {
 #[test]
 fn cannot_update_manager_as_not_manager() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 
 		assert_err!(MerkleTrees::set_manager(Origin::signed(2), 0, 2,), BadOrigin);
 	});
@@ -76,7 +76,7 @@ fn cannot_update_manager_as_not_manager() {
 #[test]
 fn can_update_manager_required_manager() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 
 		assert_ok!(MerkleTrees::set_manager_required(Origin::signed(1), 0, true,));
 
@@ -88,7 +88,7 @@ fn can_update_manager_required_manager() {
 #[test]
 fn cannot_update_manager_required_as_not_manager() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 
 		assert_err!(
 			MerkleTrees::set_manager_required(Origin::signed(2), 0, true,),
@@ -101,7 +101,7 @@ fn cannot_update_manager_required_as_not_manager() {
 fn can_add_member() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -116,7 +116,7 @@ fn can_add_member_as_manager() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -131,7 +131,7 @@ fn cannot_add_member_as_not_manager() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -147,7 +147,7 @@ fn cannot_add_member_as_not_manager() {
 #[test]
 fn should_be_able_to_set_stopped_merkle() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(1)));
 		assert_ok!(MerkleTrees::set_stopped(Origin::signed(1), 0, true));
 
 		// stopping merkle, stopped == true
@@ -165,7 +165,7 @@ fn should_be_able_to_set_stopped_merkle() {
 #[test]
 fn should_be_able_to_change_manager_with_root() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3)));
 		let call = Box::new(MerkleCall::set_manager(0, 2));
 		let res = call.dispatch_bypass_filter(RawOrigin::Root.into());
 		assert_ok!(res);
@@ -182,7 +182,7 @@ fn should_be_able_to_change_manager_with_root() {
 fn should_not_have_0_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleTrees::create_tree(Origin::signed(1), false, Some(0), true),
+			MerkleTrees::create_tree(Origin::signed(1), false, Some(0)),
 			Error::<Test>::InvalidTreeDepth,
 		);
 	});
@@ -192,7 +192,7 @@ fn should_not_have_0_depth() {
 fn should_have_min_depth() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -209,7 +209,7 @@ fn should_have_min_depth() {
 #[test]
 fn should_have_max_depth() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32)));
 	});
 }
 
@@ -217,7 +217,7 @@ fn should_have_max_depth() {
 fn should_not_have_more_than_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleTrees::create_tree(Origin::signed(1), false, Some(33), true),
+			MerkleTrees::create_tree(Origin::signed(1), false, Some(33)),
 			Error::<Test>::InvalidTreeDepth,
 		);
 	});
@@ -234,7 +234,7 @@ fn should_have_correct_root_hash_after_insertion() {
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 		let zero_h1 = ScalarData::from(zero_tree[1]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -281,7 +281,7 @@ fn should_have_correct_root_hash() {
 		}
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -322,7 +322,7 @@ fn should_be_unable_to_pass_proof_path_with_invalid_length() {
 		let key0 = ScalarData::from(key_bytes(0));
 		let key1 = ScalarData::from(key_bytes(1));
 		let key2 = ScalarData::from(key_bytes(2));
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -359,7 +359,7 @@ fn should_not_verify_invalid_proof() {
 		let key2 = ScalarData::from(key_bytes(5));
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -410,7 +410,7 @@ fn should_verify_proof_of_membership() {
 		}
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -492,7 +492,7 @@ fn should_verify_simple_zk_proof_of_membership() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -545,7 +545,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -603,7 +603,7 @@ fn should_not_verify_invalid_private_inputs() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -662,7 +662,7 @@ fn should_not_verify_invalid_path_commitments_for_membership() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -721,7 +721,7 @@ fn should_not_verify_invalid_transcript() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -794,7 +794,7 @@ fn should_verify_zk_proof_of_membership() {
 			.iter()
 			.map(|x| ScalarData(Scalar::from_bytes_mod_order(*x)))
 			.collect();
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
@@ -845,7 +845,7 @@ fn should_verify_large_zk_proof_of_membership() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32), true));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -104,7 +104,7 @@ fn can_add_member() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key.clone()]));
@@ -119,7 +119,7 @@ fn can_add_member_as_manager() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key.clone()]));
@@ -134,7 +134,7 @@ fn cannot_add_member_as_not_manager() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 		assert_err!(
@@ -195,7 +195,7 @@ fn should_have_min_depth() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key.clone()]));
@@ -237,7 +237,7 @@ fn should_have_correct_root_hash_after_insertion() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key0.clone()]));
@@ -284,7 +284,7 @@ fn should_have_correct_root_hash() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -325,7 +325,7 @@ fn should_be_unable_to_pass_proof_path_with_invalid_length() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -362,7 +362,7 @@ fn should_not_verify_invalid_proof() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -413,7 +413,7 @@ fn should_verify_proof_of_membership() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -495,7 +495,7 @@ fn should_verify_simple_zk_proof_of_membership() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -548,7 +548,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -606,7 +606,7 @@ fn should_not_verify_invalid_private_inputs() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -665,7 +665,7 @@ fn should_not_verify_invalid_path_commitments_for_membership() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -724,7 +724,7 @@ fn should_not_verify_invalid_transcript() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -797,7 +797,7 @@ fn should_verify_zk_proof_of_membership() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 
@@ -848,7 +848,7 @@ fn should_verify_large_zk_proof_of_membership() {
 		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32)));
 		let tree_id = 0;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(1), tree_id, key_id));
 

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -16,7 +16,7 @@ use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use frame_support::{assert_err, assert_ok, traits::UnfilteredDispatchable};
 use frame_system::RawOrigin;
 use merlin::Transcript;
-use rand_core::OsRng;
+use rand_chacha::ChaChaRng;
 use sp_runtime::traits::BadOrigin;
 
 fn key_bytes(x: u8) -> [u8; 32] {
@@ -565,7 +565,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 		);
 
 		let mut comms: Vec<Commitment> = comms_cr.iter().map(|x| Commitment(*x)).collect();
-		let mut rng = OsRng::default();
+		let mut rng = ChaChaRng::from_seed([1u8; 32]);
 		comms[0] = Commitment(RistrettoPoint::random(&mut rng).compress());
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
@@ -626,7 +626,7 @@ fn should_not_verify_invalid_private_inputs() {
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
 
-		let mut rng = OsRng::default();
+		let mut rng = ChaChaRng::from_seed([1u8; 32]);
 		comms.push(Commitment(RistrettoPoint::random(&mut rng).compress()));
 
 		assert_err!(
@@ -684,7 +684,7 @@ fn should_not_verify_invalid_path_commitments_for_membership() {
 		let comms: Vec<Commitment> = comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let mut leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let mut proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
-		let mut rng = OsRng::default();
+		let mut rng = ChaChaRng::from_seed([1u8; 32]);
 		leaf_index_comms[0] = Commitment(RistrettoPoint::random(&mut rng).compress());
 		proof_comms[0] = Commitment(RistrettoPoint::random(&mut rng).compress());
 

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -36,14 +36,14 @@ fn default_hasher(num_gens: usize) -> Poseidon {
 #[test]
 fn can_create_tree() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 	});
 }
 
 #[test]
 fn can_update_manager_when_required() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
 
 		assert_ok!(MerkleTrees::set_manager(Origin::signed(1), 0, 2,));
 
@@ -55,7 +55,7 @@ fn can_update_manager_when_required() {
 #[test]
 fn can_update_manager_when_not_required() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 
 		assert_ok!(MerkleTrees::set_manager(Origin::signed(1), 0, 2,));
 
@@ -67,7 +67,7 @@ fn can_update_manager_when_not_required() {
 #[test]
 fn cannot_update_manager_as_not_manager() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 
 		assert_err!(MerkleTrees::set_manager(Origin::signed(2), 0, 2,), BadOrigin);
 	});
@@ -76,7 +76,7 @@ fn cannot_update_manager_as_not_manager() {
 #[test]
 fn can_update_manager_required_manager() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 
 		assert_ok!(MerkleTrees::set_manager_required(Origin::signed(1), 0, true,));
 
@@ -88,7 +88,7 @@ fn can_update_manager_required_manager() {
 #[test]
 fn cannot_update_manager_required_as_not_manager() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 
 		assert_err!(
 			MerkleTrees::set_manager_required(Origin::signed(2), 0, true,),
@@ -102,7 +102,7 @@ fn can_add_member() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key.clone()]));
 	});
 }
@@ -112,7 +112,7 @@ fn can_add_member_as_manager() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key.clone()]));
 	});
 }
@@ -122,7 +122,7 @@ fn cannot_add_member_as_not_manager() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
 		assert_err!(
 			MerkleTrees::add_members(Origin::signed(2), 0, vec![key.clone()]),
 			Error::<Test>::ManagerIsRequired
@@ -133,7 +133,7 @@ fn cannot_add_member_as_not_manager() {
 #[test]
 fn should_be_able_to_set_stopped_merkle() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(1), true));
 		assert_ok!(MerkleTrees::set_stopped(Origin::signed(1), 0, true));
 
 		// stopping merkle, stopped == true
@@ -151,7 +151,7 @@ fn should_be_able_to_set_stopped_merkle() {
 #[test]
 fn should_be_able_to_change_manager_with_root() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), true, Some(3), true));
 		let call = Box::new(MerkleCall::set_manager(0, 2));
 		let res = call.dispatch_bypass_filter(RawOrigin::Root.into());
 		assert_ok!(res);
@@ -168,7 +168,7 @@ fn should_be_able_to_change_manager_with_root() {
 fn should_not_have_0_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleTrees::create_tree(Origin::signed(1), false, Some(0)),
+			MerkleTrees::create_tree(Origin::signed(1), false, Some(0), true),
 			Error::<Test>::InvalidTreeDepth,
 		);
 	});
@@ -178,7 +178,7 @@ fn should_not_have_0_depth() {
 fn should_have_min_depth() {
 	new_test_ext().execute_with(|| {
 		let key = ScalarData::from(key_bytes(1));
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
 
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key.clone()]));
 		assert_err!(
@@ -191,7 +191,7 @@ fn should_have_min_depth() {
 #[test]
 fn should_have_max_depth() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32), true));
 	});
 }
 
@@ -199,7 +199,7 @@ fn should_have_max_depth() {
 fn should_not_have_more_than_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleTrees::create_tree(Origin::signed(1), false, Some(33),),
+			MerkleTrees::create_tree(Origin::signed(1), false, Some(33), true),
 			Error::<Test>::InvalidTreeDepth,
 		);
 	});
@@ -216,7 +216,7 @@ fn should_have_correct_root_hash_after_insertion() {
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 		let zero_h1 = ScalarData::from(zero_tree[1]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2),true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![key0.clone()]));
 
 		let keyh1 = Poseidon_hash_2(key0.0, zero_h0.0, &h);
@@ -258,7 +258,7 @@ fn should_have_correct_root_hash() {
 		}
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4), true));
 		let keys_data: Vec<ScalarData> = keys.iter().map(|x| ScalarData(*x)).collect();
 		assert_ok!(MerkleTrees::add_members(Origin::signed(0), 0, keys_data.clone()));
 
@@ -293,7 +293,7 @@ fn should_be_unable_to_pass_proof_path_with_invalid_length() {
 		let key0 = ScalarData::from(key_bytes(0));
 		let key1 = ScalarData::from(key_bytes(1));
 		let key2 = ScalarData::from(key_bytes(2));
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2),true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(0), 0, vec![
 			key0.clone(),
 			key1.clone(),
@@ -324,7 +324,7 @@ fn should_not_verify_invalid_proof() {
 		let key2 = ScalarData::from(key_bytes(5));
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(2),true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![
 			key0.clone(),
 			key1.clone(),
@@ -369,7 +369,7 @@ fn should_verify_proof_of_membership() {
 		}
 		let zero_h0 = ScalarData::from(zero_tree[0]);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(4), true));
 		let keys_data: Vec<ScalarData> = keys.iter().map(|x| ScalarData(*x)).collect();
 		assert_ok!(MerkleTrees::add_members(Origin::signed(0), 0, keys_data.clone()));
 
@@ -445,7 +445,7 @@ fn should_verify_simple_zk_proof_of_membership() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![ScalarData(leaf)]));
 		let root = MerkleTrees::get_merkle_root(0).unwrap();
 
@@ -491,7 +491,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![ScalarData(leaf)]));
 		let root = MerkleTrees::get_merkle_root(0).unwrap();
 
@@ -542,7 +542,7 @@ fn should_not_verify_invalid_private_inputs() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![ScalarData(leaf)]));
 		let root = MerkleTrees::get_merkle_root(0).unwrap();
 
@@ -595,7 +595,7 @@ fn should_not_verify_invalid_path_commitments_for_membership() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![ScalarData(leaf)]));
 		let root = MerkleTrees::get_merkle_root(0).unwrap();
 
@@ -647,7 +647,7 @@ fn should_not_verify_invalid_transcript() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(1), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![ScalarData(leaf)]));
 		let root = MerkleTrees::get_merkle_root(0).unwrap();
 
@@ -713,7 +713,7 @@ fn should_verify_zk_proof_of_membership() {
 			.iter()
 			.map(|x| ScalarData(Scalar::from_bytes_mod_order(*x)))
 			.collect();
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(3), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, keys_data));
 
 		let root = MerkleTrees::get_merkle_root(0).unwrap();
@@ -757,7 +757,7 @@ fn should_verify_large_zk_proof_of_membership() {
 		let leaf = ftree.generate_secrets();
 		ftree.tree.add_leaves(vec![leaf.to_bytes()], None);
 
-		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32),));
+		assert_ok!(MerkleTrees::create_tree(Origin::signed(1), false, Some(32), true));
 		assert_ok!(MerkleTrees::add_members(Origin::signed(1), 0, vec![ScalarData(leaf)]));
 
 		let root = MerkleTrees::get_merkle_root(0).unwrap();

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -1,9 +1,7 @@
-use crate::utils::keys::get_bp_gen_bytes;
-use crate::utils::keys::from_bytes_to_bp_gens;
 use super::*;
 use crate::{
 	mock::*,
-	utils::keys::{Commitment, ScalarData},
+	utils::keys::{from_bytes_to_bp_gens, get_bp_gen_bytes, Commitment, ScalarData},
 };
 use bulletproofs::{r1cs::Prover, BulletproofGens, PedersenGens};
 use bulletproofs_gadgets::{
@@ -630,7 +628,6 @@ fn should_not_verify_invalid_private_inputs() {
 
 		let mut rng = OsRng::default();
 		comms.push(Commitment(RistrettoPoint::random(&mut rng).compress()));
-
 
 		assert_err!(
 			MerkleTrees::verify_zk_membership_proof(

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -461,6 +461,7 @@ fn should_verify_simple_zk_proof_of_membership() {
 		let comms: Vec<Commitment> = comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_ok!(MerkleTrees::verify_zk_membership_proof(
 			0,
 			0,
@@ -472,6 +473,7 @@ fn should_verify_simple_zk_proof_of_membership() {
 			proof_comms,
 			ScalarData::zero(),
 			ScalarData::zero(),
+			hasher,
 		));
 	});
 }
@@ -509,6 +511,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 		comms[0] = Commitment(RistrettoPoint::random(&mut rng).compress());
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_err!(
 			MerkleTrees::verify_zk_membership_proof(
 				0,
@@ -521,6 +524,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 				proof_comms,
 				ScalarData::zero(),
 				ScalarData::zero(),
+				hasher,
 			),
 			Error::<Test>::ZkVericationFailed
 		);
@@ -562,6 +566,7 @@ fn should_not_verify_invalid_private_inputs() {
 		let mut rng = OsRng::default();
 		comms.push(Commitment(RistrettoPoint::random(&mut rng).compress()));
 
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_err!(
 			MerkleTrees::verify_zk_membership_proof(
 				0,
@@ -574,6 +579,7 @@ fn should_not_verify_invalid_private_inputs() {
 				proof_comms,
 				ScalarData::zero(),
 				ScalarData::zero(),
+				hasher,
 			),
 			Error::<Test>::InvalidPrivateInputs
 		);
@@ -614,6 +620,7 @@ fn should_not_verify_invalid_path_commitments_for_membership() {
 		let mut rng = OsRng::default();
 		leaf_index_comms[0] = Commitment(RistrettoPoint::random(&mut rng).compress());
 		proof_comms[0] = Commitment(RistrettoPoint::random(&mut rng).compress());
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_err!(
 			MerkleTrees::verify_zk_membership_proof(
 				0,
@@ -626,6 +633,7 @@ fn should_not_verify_invalid_path_commitments_for_membership() {
 				proof_comms,
 				ScalarData::zero(),
 				ScalarData::zero(),
+				hasher,
 			),
 			Error::<Test>::ZkVericationFailed
 		);
@@ -663,6 +671,7 @@ fn should_not_verify_invalid_transcript() {
 		let comms: Vec<Commitment> = comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_err!(
 			MerkleTrees::verify_zk_membership_proof(
 				0,
@@ -675,6 +684,7 @@ fn should_not_verify_invalid_transcript() {
 				proof_comms,
 				ScalarData::zero(),
 				ScalarData::zero(),
+				hasher,
 			),
 			Error::<Test>::ZkVericationFailed
 		);
@@ -729,6 +739,7 @@ fn should_verify_zk_proof_of_membership() {
 		let comms: Vec<Commitment> = comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_ok!(MerkleTrees::verify_zk_membership_proof(
 			0,
 			0,
@@ -740,6 +751,7 @@ fn should_verify_zk_proof_of_membership() {
 			proof_comms,
 			ScalarData::zero(),
 			ScalarData::zero(),
+			hasher,
 		));
 	});
 }
@@ -773,6 +785,7 @@ fn should_verify_large_zk_proof_of_membership() {
 		let comms: Vec<Commitment> = comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let leaf_index_comms: Vec<Commitment> = leaf_index_comms_cr.iter().map(|x| Commitment(*x)).collect();
 		let proof_comms: Vec<Commitment> = proof_comms_cr.iter().map(|x| Commitment(*x)).collect();
+		let hasher = MerkleTrees::get_poseidon_hasher(0).unwrap();
 		assert_ok!(MerkleTrees::verify_zk_membership_proof(
 			0,
 			0,
@@ -784,6 +797,7 @@ fn should_verify_large_zk_proof_of_membership() {
 			proof_comms,
 			ScalarData::zero(),
 			ScalarData::zero(),
+			hasher,
 		));
 	});
 }

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -1,5 +1,7 @@
 //! All the traits exposed to be used in other custom pallets
+use crate::VerifyingKeyData;
 use crate::Config;
+use bulletproofs_gadgets::poseidon::builder::Poseidon;
 use crate::utils::keys::{Commitment, ScalarData};
 use bulletproofs::PedersenGens;
 pub use frame_support::dispatch;
@@ -31,7 +33,7 @@ pub trait Tree<T: Config> {
 	/// Can only be called by the manager if the manager is required
 	fn add_nullifier(sender: T::AccountId, id: T::TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
 	/// Set verifying key in storage
-	fn set_verifying_key(key_id: T::KeyId, key: Vec<u8>) -> Result<(), dispatch::DispatchError>;
+	fn set_verifying_key(key_id: T::KeyId, key: VerifyingKeyData) -> Result<(), dispatch::DispatchError>;
 	/// Set verifying key for tree
 	fn set_verifying_key_for_tree(key_id: T::KeyId, tree_id: T::TreeId) -> Result<(), dispatch::DispatchError>;
 	/// Verify membership proof
@@ -48,6 +50,7 @@ pub trait Tree<T: Config> {
 		proof_commitments: Vec<Commitment>,
 		recipient: ScalarData,
 		relayer: ScalarData,
+		hash_params: Poseidon,
 	) -> Result<(), dispatch::DispatchError>;
 	fn verify_zk(
 		pc_gens: PedersenGens,
@@ -60,5 +63,6 @@ pub trait Tree<T: Config> {
 		proof_commitments: Vec<Commitment>,
 		recipient: ScalarData,
 		relayer: ScalarData,
+		hash_params: Poseidon,
 	) -> Result<(), dispatch::DispatchError>;
 }

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -1,41 +1,45 @@
 //! All the traits exposed to be used in other custom pallets
-
+use crate::Config;
 use crate::utils::keys::{Commitment, ScalarData};
 use bulletproofs::PedersenGens;
 pub use frame_support::dispatch;
 use sp_std::vec::Vec;
 
 /// Tree trait definition to be used in other pallets
-pub trait Tree<AccountId, BlockNumber, TreeId> {
+pub trait Tree<T: Config> {
 	/// Check if nullifier is already used, in which case return an error
-	fn has_used_nullifier(id: TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
+	fn has_used_nullifier(id: T::TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
 	/// Sets stopped flag in storage. This flag doesn't do much by itself, it is
 	/// up to higher-level pallet to find the use for it
 	/// Can only be called by the manager, regardless if the manager is required
-	fn set_stopped(sender: AccountId, tree_id: TreeId, stopped: bool) -> Result<(), dispatch::DispatchError>;
+	fn set_stopped(sender: T::AccountId, tree_id: T::TreeId, stopped: bool) -> Result<(), dispatch::DispatchError>;
 	/// Sets whether the manager is required for guarded calls.
 	/// Can only be called by the current manager
 	fn set_manager_required(
-		sender: AccountId,
-		id: TreeId,
+		sender: T::AccountId,
+		id: T::TreeId,
 		is_manager_required: bool,
 	) -> Result<(), dispatch::DispatchError>;
 	/// Sets manager account id
 	/// Can only be called by the current manager
-	fn set_manager(sender: AccountId, id: TreeId, new_manager: AccountId) -> Result<(), dispatch::DispatchError>;
+	fn set_manager(sender: T::AccountId, id: T::TreeId, new_manager: T::AccountId) -> Result<(), dispatch::DispatchError>;
 	/// Creates a new Tree tree, including a manager for that tree
-	fn create_tree(sender: AccountId, is_manager_required: bool, depth: u8) -> Result<TreeId, dispatch::DispatchError>;
+	fn create_tree(sender: T::AccountId, is_manager_required: bool, depth: u8, is_vkey_required: bool) -> Result<T::TreeId, dispatch::DispatchError>;
 	/// Adds members/leaves to the tree
-	fn add_members(sender: AccountId, id: TreeId, members: Vec<ScalarData>) -> Result<(), dispatch::DispatchError>;
+	fn add_members(sender: T::AccountId, id: T::TreeId, members: Vec<ScalarData>) -> Result<(), dispatch::DispatchError>;
 	/// Adds a nullifier to the storage
 	/// Can only be called by the manager if the manager is required
-	fn add_nullifier(sender: AccountId, id: TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
+	fn add_nullifier(sender: T::AccountId, id: T::TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
+	/// Set verifying key in storage
+	fn set_verifying_key(key_id: T::KeyId, key: Vec<u8>) -> Result<(), dispatch::DispatchError>;
+	/// Set verifying key for tree
+	fn set_verifying_key_for_tree(key_id: T::KeyId, tree_id: T::TreeId) -> Result<(), dispatch::DispatchError>;
 	/// Verify membership proof
-	fn verify(id: TreeId, leaf: ScalarData, path: Vec<(bool, ScalarData)>) -> Result<(), dispatch::DispatchError>;
+	fn verify(id: T::TreeId, leaf: ScalarData, path: Vec<(bool, ScalarData)>) -> Result<(), dispatch::DispatchError>;
 	/// Verify zero-knowladge membership proof
 	fn verify_zk_membership_proof(
-		tree_id: TreeId,
-		cached_block: BlockNumber,
+		tree_id: T::TreeId,
+		cached_block: T::BlockNumber,
 		cached_root: ScalarData,
 		comms: Vec<Commitment>,
 		nullifier_hash: ScalarData,

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -28,11 +28,15 @@ pub trait Tree<T: Config> {
 	fn create_tree(sender: T::AccountId, is_manager_required: bool, depth: u8, is_vkey_required: bool) -> Result<T::TreeId, dispatch::DispatchError>;
 	/// Initializes the tree with the root hash and edge nodes, must happen after keys are set
 	fn initialize_tree(tree_id: T::TreeId, key_id: T::KeyId) -> Result<(), dispatch::DispatchError>;
+	/// Checks if a tree is initialized
+	fn is_initialized(tree_id: T::TreeId) -> Result<bool, dispatch::DispatchError>;
 	/// Adds members/leaves to the tree
 	fn add_members(sender: T::AccountId, id: T::TreeId, members: Vec<ScalarData>) -> Result<(), dispatch::DispatchError>;
 	/// Adds a nullifier to the storage
 	/// Can only be called by the manager if the manager is required
 	fn add_nullifier(sender: T::AccountId, id: T::TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
+	/// Add verifying key to storage and increment the next available key id
+	fn add_verifying_key(key: Vec<u8>) -> Result<T::KeyId, dispatch::DispatchError>;
 	/// Set verifying key in storage
 	fn set_verifying_key(key_id: T::KeyId, key: Vec<u8>) -> Result<(), dispatch::DispatchError>;
 	/// Set verifying key for tree

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -1,5 +1,4 @@
 //! All the traits exposed to be used in other custom pallets
-use crate::VerifyingKeyData;
 use crate::Config;
 use bulletproofs_gadgets::poseidon::builder::Poseidon;
 use crate::utils::keys::{Commitment, ScalarData};
@@ -27,13 +26,15 @@ pub trait Tree<T: Config> {
 	fn set_manager(sender: T::AccountId, id: T::TreeId, new_manager: T::AccountId) -> Result<(), dispatch::DispatchError>;
 	/// Creates a new Tree tree, including a manager for that tree
 	fn create_tree(sender: T::AccountId, is_manager_required: bool, depth: u8, is_vkey_required: bool) -> Result<T::TreeId, dispatch::DispatchError>;
+	/// Initializes the tree with the root hash and edge nodes, must happen after keys are set
+	fn initialize_tree(tree_id: T::TreeId, key_id: T::KeyId) -> Result<(), dispatch::DispatchError>;
 	/// Adds members/leaves to the tree
 	fn add_members(sender: T::AccountId, id: T::TreeId, members: Vec<ScalarData>) -> Result<(), dispatch::DispatchError>;
 	/// Adds a nullifier to the storage
 	/// Can only be called by the manager if the manager is required
 	fn add_nullifier(sender: T::AccountId, id: T::TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
 	/// Set verifying key in storage
-	fn set_verifying_key(key_id: T::KeyId, key: VerifyingKeyData) -> Result<(), dispatch::DispatchError>;
+	fn set_verifying_key(key_id: T::KeyId, key: Vec<u8>) -> Result<(), dispatch::DispatchError>;
 	/// Set verifying key for tree
 	fn set_verifying_key_for_tree(key_id: T::KeyId, tree_id: T::TreeId) -> Result<(), dispatch::DispatchError>;
 	/// Verify membership proof
@@ -50,7 +51,6 @@ pub trait Tree<T: Config> {
 		proof_commitments: Vec<Commitment>,
 		recipient: ScalarData,
 		relayer: ScalarData,
-		hash_params: Poseidon,
 	) -> Result<(), dispatch::DispatchError>;
 	fn verify_zk(
 		pc_gens: PedersenGens,
@@ -63,6 +63,6 @@ pub trait Tree<T: Config> {
 		proof_commitments: Vec<Commitment>,
 		recipient: ScalarData,
 		relayer: ScalarData,
-		hash_params: Poseidon,
+		hash_params: &Poseidon,
 	) -> Result<(), dispatch::DispatchError>;
 }

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -35,7 +35,6 @@ pub trait Tree<T: Config> {
 		sender: T::AccountId,
 		is_manager_required: bool,
 		depth: u8,
-		is_vkey_required: bool,
 	) -> Result<T::TreeId, dispatch::DispatchError>;
 	/// Initializes the tree with the root hash and edge nodes, must happen
 	/// after keys are set

--- a/pallets/merkle/src/traits.rs
+++ b/pallets/merkle/src/traits.rs
@@ -1,8 +1,10 @@
 //! All the traits exposed to be used in other custom pallets
-use crate::Config;
-use bulletproofs_gadgets::poseidon::builder::Poseidon;
-use crate::utils::keys::{Commitment, ScalarData};
+use crate::{
+	utils::keys::{Commitment, ScalarData},
+	Config,
+};
 use bulletproofs::PedersenGens;
+use bulletproofs_gadgets::poseidon::builder::Poseidon;
 pub use frame_support::dispatch;
 use sp_std::vec::Vec;
 
@@ -23,18 +25,33 @@ pub trait Tree<T: Config> {
 	) -> Result<(), dispatch::DispatchError>;
 	/// Sets manager account id
 	/// Can only be called by the current manager
-	fn set_manager(sender: T::AccountId, id: T::TreeId, new_manager: T::AccountId) -> Result<(), dispatch::DispatchError>;
+	fn set_manager(
+		sender: T::AccountId,
+		id: T::TreeId,
+		new_manager: T::AccountId,
+	) -> Result<(), dispatch::DispatchError>;
 	/// Creates a new Tree tree, including a manager for that tree
-	fn create_tree(sender: T::AccountId, is_manager_required: bool, depth: u8, is_vkey_required: bool) -> Result<T::TreeId, dispatch::DispatchError>;
-	/// Initializes the tree with the root hash and edge nodes, must happen after keys are set
+	fn create_tree(
+		sender: T::AccountId,
+		is_manager_required: bool,
+		depth: u8,
+		is_vkey_required: bool,
+	) -> Result<T::TreeId, dispatch::DispatchError>;
+	/// Initializes the tree with the root hash and edge nodes, must happen
+	/// after keys are set
 	fn initialize_tree(tree_id: T::TreeId, key_id: T::KeyId) -> Result<(), dispatch::DispatchError>;
 	/// Checks if a tree is initialized
 	fn is_initialized(tree_id: T::TreeId) -> Result<bool, dispatch::DispatchError>;
 	/// Adds members/leaves to the tree
-	fn add_members(sender: T::AccountId, id: T::TreeId, members: Vec<ScalarData>) -> Result<(), dispatch::DispatchError>;
+	fn add_members(
+		sender: T::AccountId,
+		id: T::TreeId,
+		members: Vec<ScalarData>,
+	) -> Result<(), dispatch::DispatchError>;
 	/// Adds a nullifier to the storage
 	/// Can only be called by the manager if the manager is required
-	fn add_nullifier(sender: T::AccountId, id: T::TreeId, nullifier: ScalarData) -> Result<(), dispatch::DispatchError>;
+	fn add_nullifier(sender: T::AccountId, id: T::TreeId, nullifier: ScalarData)
+		-> Result<(), dispatch::DispatchError>;
 	/// Add verifying key to storage and increment the next available key id
 	fn add_verifying_key(key: Vec<u8>) -> Result<T::KeyId, dispatch::DispatchError>;
 	/// Set verifying key in storage

--- a/pallets/merkle/src/utils/keys.rs
+++ b/pallets/merkle/src/utils/keys.rs
@@ -137,12 +137,41 @@ impl ScalarData {
 	}
 }
 
+#[derive(Encode, Decode, Clone)]
 pub enum VerifyingKeyData {
 	Poseidon(PoseidonVerifyingKey),
 }
 
+impl PartialEq for VerifyingKeyData {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+        	Self::Poseidon(data) => {
+        		match other {
+        			Self::Poseidon(other_data) => {
+        				let self_gens = data.bp_gens;
+        				let other_gens = other_data.bp_gens;
+
+        				if self_gens.gens_capacity != other_gens.gens_capacity {
+        					return false;
+        				} else if self_gens.party_capacity != other_gens.party_capacity {
+        					return false;
+        				} else if self_gens.G_vec.len() != other_gens.G_vec.len() {
+        					return false;
+        				} else if self_gens.H_vec.len() != other_gens.H_vec.len() {
+        					return false;
+        				}
+
+        				true
+        			}
+        		}
+        	},
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct PoseidonVerifyingKey {
-	bp_gens: BulletproofGens,
+	pub bp_gens: BulletproofGens,
 }
 
 // pub struct BulletproofGens {
@@ -201,6 +230,8 @@ impl Encode for PoseidonVerifyingKey {
 		bytes.using_encoded(f)
 	}
 }
+
+impl EncodeLike for PoseidonVerifyingKey {}
 
 impl Decode for PoseidonVerifyingKey {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {

--- a/pallets/merkle/src/utils/keys.rs
+++ b/pallets/merkle/src/utils/keys.rs
@@ -3,13 +3,11 @@
 use sha2::Sha512;
 use sp_std::prelude::*;
 
+use bulletproofs::BulletproofGens;
 use codec::{Decode, Encode, EncodeLike, Input};
 use curve25519_dalek::{
 	ristretto::{CompressedRistretto, RistrettoPoint},
 	scalar::Scalar,
-};
-use bulletproofs::{
-	BulletproofGens
 };
 use sp_std::vec::Vec;
 
@@ -138,108 +136,119 @@ impl ScalarData {
 }
 
 pub fn get_bp_gen_bytes(bp_gens: &BulletproofGens) -> Vec<u8> {
-    let g_vec_bytes = bp_gens.G_vec.iter().map(|vec| {
-        vec.iter().map(|pt| pt.compress().to_bytes()).fold(vec![], |mut acc, curr| {
-            // inside inner len (except this should always be 32 bytes so we can drop the length)
-            // NOT_NEEDED - acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
-            // inside inner data
-            acc.append(&mut curr.to_vec());
-            acc
-        })
-    }).fold(vec![], |mut acc, curr| {
-        // inner len
-        acc.append(&mut (curr.to_vec().len() as u32).to_be_bytes().to_vec());
-        // inner data
-        acc.append(&mut curr.to_vec());
-        acc
-    });
+	let g_vec_bytes = bp_gens
+		.G_vec
+		.iter()
+		.map(|vec| {
+			vec.iter()
+				.map(|pt| pt.compress().to_bytes())
+				.fold(vec![], |mut acc, curr| {
+					// inside inner len (except this should always be 32 bytes so we can drop the
+					// length) NOT_NEEDED - acc.append(&mut
+					// curr.to_vec().len().to_be_bytes().to_vec()); inside inner data
+					acc.append(&mut curr.to_vec());
+					acc
+				})
+		})
+		.fold(vec![], |mut acc, curr| {
+			// inner len
+			acc.append(&mut (curr.to_vec().len() as u32).to_be_bytes().to_vec());
+			// inner data
+			acc.append(&mut curr.to_vec());
+			acc
+		});
 
-    let h_vec_bytes = bp_gens.H_vec.iter().map(|vec| {
-        vec.iter().map(|pt| pt.compress().to_bytes()).fold(vec![], |mut acc, curr| {
-            // inside inner len (except this should always be 32 bytes so we can drop the length)
-            // NOT_NEEDED - acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
-            // inside inner data
-            acc.append(&mut curr.to_vec());
-            acc
-        })
-    }).fold(vec![], |mut acc, curr| {
-        // inner len
-        acc.append(&mut (curr.to_vec().len() as u32).to_be_bytes().to_vec());
-        // inner data
-        acc.append(&mut curr.to_vec());
-        acc
-    });
+	let h_vec_bytes = bp_gens
+		.H_vec
+		.iter()
+		.map(|vec| {
+			vec.iter()
+				.map(|pt| pt.compress().to_bytes())
+				.fold(vec![], |mut acc, curr| {
+					// inside inner len (except this should always be 32 bytes so we can drop the
+					// length) NOT_NEEDED - acc.append(&mut
+					// curr.to_vec().len().to_be_bytes().to_vec()); inside inner data
+					acc.append(&mut curr.to_vec());
+					acc
+				})
+		})
+		.fold(vec![], |mut acc, curr| {
+			// inner len
+			acc.append(&mut (curr.to_vec().len() as u32).to_be_bytes().to_vec());
+			// inner data
+			acc.append(&mut curr.to_vec());
+			acc
+		});
 
-    let mut bytes = vec![];
-    bytes.extend_from_slice(&(bp_gens.gens_capacity as u32).to_be_bytes());
-    bytes.extend_from_slice(&(bp_gens.party_capacity as u32).to_be_bytes());
-    bytes.extend_from_slice(&(g_vec_bytes.len() as u32).to_be_bytes());
-    bytes.extend_from_slice(&g_vec_bytes);
-    bytes.extend_from_slice(&(h_vec_bytes.len() as u32).to_be_bytes());
-    bytes.extend_from_slice(&h_vec_bytes);
-    bytes
+	let mut bytes = vec![];
+	bytes.extend_from_slice(&(bp_gens.gens_capacity as u32).to_be_bytes());
+	bytes.extend_from_slice(&(bp_gens.party_capacity as u32).to_be_bytes());
+	bytes.extend_from_slice(&(g_vec_bytes.len() as u32).to_be_bytes());
+	bytes.extend_from_slice(&g_vec_bytes);
+	bytes.extend_from_slice(&(h_vec_bytes.len() as u32).to_be_bytes());
+	bytes.extend_from_slice(&h_vec_bytes);
+	bytes
 }
 
 pub fn from_bytes_to_bp_gens(mut input: &[u8]) -> BulletproofGens {
-    let mut gens_capacity_bytes = [0u8; 4];
-    let _ = input.read(&mut gens_capacity_bytes);
-    let gens_capacity: usize = u32::from_be_bytes(gens_capacity_bytes) as usize;
+	let mut gens_capacity_bytes = [0u8; 4];
+	let _ = input.read(&mut gens_capacity_bytes);
+	let gens_capacity: usize = u32::from_be_bytes(gens_capacity_bytes) as usize;
 
-    let mut party_capacity_bytes = [0u8; 4];
-    let _ = input.read(&mut party_capacity_bytes);
-    let party_capacity: usize = u32::from_be_bytes(party_capacity_bytes) as usize;
+	let mut party_capacity_bytes = [0u8; 4];
+	let _ = input.read(&mut party_capacity_bytes);
+	let party_capacity: usize = u32::from_be_bytes(party_capacity_bytes) as usize;
 
-    let mut g_vec_len_bytes = [0u8; 4];
-    let _ = input.read(&mut g_vec_len_bytes);
-    let g_vec_len: usize = u32::from_be_bytes(g_vec_len_bytes) as usize;
-    let mut g_vec = vec![0u8; g_vec_len];
-    let _ = input.read(&mut g_vec);
-    let mut g_slice = g_vec.as_slice();
-    let mut vec_of_vecs_g = vec![];
-    while g_slice.len() > 0 {
-        let mut inner_vec_len = [0u8; 4];
-        let _ = g_slice.read(&mut inner_vec_len);
-        let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len) as usize;
-        let mut inner_vec = vec![0u8; inner_vec_len_u32];
-        let _ = g_slice.read(&mut inner_vec);
-        let mut inner_g_slice = inner_vec.as_slice();
-        let mut vec_of_points = vec![];
-        while inner_g_slice.len() > 0 {
-            let mut inside_inner_g_slice = [0u8; 32];
-            let _ = inner_g_slice.read(&mut inside_inner_g_slice);
-            vec_of_points.push(CompressedRistretto(inside_inner_g_slice).decompress().unwrap());
-        }
-        vec_of_vecs_g.push(vec_of_points);
-    }
+	let mut g_vec_len_bytes = [0u8; 4];
+	let _ = input.read(&mut g_vec_len_bytes);
+	let g_vec_len: usize = u32::from_be_bytes(g_vec_len_bytes) as usize;
+	let mut g_vec = vec![0u8; g_vec_len];
+	let _ = input.read(&mut g_vec);
+	let mut g_slice = g_vec.as_slice();
+	let mut vec_of_vecs_g = vec![];
+	while g_slice.len() > 0 {
+		let mut inner_vec_len = [0u8; 4];
+		let _ = g_slice.read(&mut inner_vec_len);
+		let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len) as usize;
+		let mut inner_vec = vec![0u8; inner_vec_len_u32];
+		let _ = g_slice.read(&mut inner_vec);
+		let mut inner_g_slice = inner_vec.as_slice();
+		let mut vec_of_points = vec![];
+		while inner_g_slice.len() > 0 {
+			let mut inside_inner_g_slice = [0u8; 32];
+			let _ = inner_g_slice.read(&mut inside_inner_g_slice);
+			vec_of_points.push(CompressedRistretto(inside_inner_g_slice).decompress().unwrap());
+		}
+		vec_of_vecs_g.push(vec_of_points);
+	}
 
+	let mut h_vec_len_bytes = [0u8; 4];
+	let _ = input.read(&mut h_vec_len_bytes);
+	let h_vec_len: usize = u32::from_be_bytes(h_vec_len_bytes) as usize;
+	let mut h_vec = vec![0u8; h_vec_len];
+	let _ = input.read(&mut h_vec);
+	let mut h_slice = h_vec.as_slice();
+	let mut vec_of_vecs_h = vec![];
+	while h_slice.len() > 0 {
+		let mut inner_vec_len = [0u8; 4];
+		let _ = h_slice.read(&mut inner_vec_len);
+		let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len) as usize;
+		let mut inner_vec = vec![0u8; inner_vec_len_u32];
+		let _ = h_slice.read(&mut inner_vec);
+		let mut inner_h_slice = inner_vec.as_slice();
+		let mut vec_of_points = vec![];
+		while inner_h_slice.len() > 0 {
+			let mut inside_inner_h_slice = [0u8; 32];
+			let _ = inner_h_slice.read(&mut inside_inner_h_slice);
+			vec_of_points.push(CompressedRistretto(inside_inner_h_slice).decompress().unwrap());
+		}
+		vec_of_vecs_h.push(vec_of_points);
+	}
 
-    let mut h_vec_len_bytes = [0u8; 4];
-    let _ = input.read(&mut h_vec_len_bytes);
-    let h_vec_len: usize = u32::from_be_bytes(h_vec_len_bytes) as usize;
-    let mut h_vec = vec![0u8; h_vec_len];
-    let _ = input.read(&mut h_vec);
-    let mut h_slice = h_vec.as_slice();
-    let mut vec_of_vecs_h = vec![];
-    while h_slice.len() > 0 {
-        let mut inner_vec_len = [0u8; 4];
-        let _ = h_slice.read(&mut inner_vec_len);
-        let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len) as usize;
-        let mut inner_vec = vec![0u8; inner_vec_len_u32];
-        let _ = h_slice.read(&mut inner_vec);
-        let mut inner_h_slice = inner_vec.as_slice();
-        let mut vec_of_points = vec![];
-        while inner_h_slice.len() > 0 {
-            let mut inside_inner_h_slice = [0u8; 32];
-            let _ = inner_h_slice.read(&mut inside_inner_h_slice);
-            vec_of_points.push(CompressedRistretto(inside_inner_h_slice).decompress().unwrap());
-        }
-        vec_of_vecs_h.push(vec_of_points);
-    }
-    
-    BulletproofGens {
-        gens_capacity,
-        party_capacity, 
-        G_vec: vec_of_vecs_g,
-        H_vec: vec_of_vecs_h,
-    }
+	BulletproofGens {
+		gens_capacity,
+		party_capacity,
+		G_vec: vec_of_vecs_g,
+		H_vec: vec_of_vecs_h,
+	}
 }

--- a/pallets/merkle/src/utils/keys.rs
+++ b/pallets/merkle/src/utils/keys.rs
@@ -137,168 +137,109 @@ impl ScalarData {
 	}
 }
 
-#[derive(Encode, Decode, Clone)]
-pub enum VerifyingKeyData {
-	Poseidon(PoseidonVerifyingKey),
+pub fn get_bp_gen_bytes(bp_gens: &BulletproofGens) -> Vec<u8> {
+    let g_vec_bytes = bp_gens.G_vec.iter().map(|vec| {
+        vec.iter().map(|pt| pt.compress().to_bytes()).fold(vec![], |mut acc, curr| {
+            // inside inner len (except this should always be 32 bytes so we can drop the length)
+            // NOT_NEEDED - acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
+            // inside inner data
+            acc.append(&mut curr.to_vec());
+            acc
+        })
+    }).fold(vec![], |mut acc, curr| {
+        // inner len
+        acc.append(&mut (curr.to_vec().len() as u32).to_be_bytes().to_vec());
+        // inner data
+        acc.append(&mut curr.to_vec());
+        acc
+    });
+
+    let h_vec_bytes = bp_gens.H_vec.iter().map(|vec| {
+        vec.iter().map(|pt| pt.compress().to_bytes()).fold(vec![], |mut acc, curr| {
+            // inside inner len (except this should always be 32 bytes so we can drop the length)
+            // NOT_NEEDED - acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
+            // inside inner data
+            acc.append(&mut curr.to_vec());
+            acc
+        })
+    }).fold(vec![], |mut acc, curr| {
+        // inner len
+        acc.append(&mut (curr.to_vec().len() as u32).to_be_bytes().to_vec());
+        // inner data
+        acc.append(&mut curr.to_vec());
+        acc
+    });
+
+    let mut bytes = vec![];
+    bytes.extend_from_slice(&(bp_gens.gens_capacity as u32).to_be_bytes());
+    bytes.extend_from_slice(&(bp_gens.party_capacity as u32).to_be_bytes());
+    bytes.extend_from_slice(&(g_vec_bytes.len() as u32).to_be_bytes());
+    bytes.extend_from_slice(&g_vec_bytes);
+    bytes.extend_from_slice(&(h_vec_bytes.len() as u32).to_be_bytes());
+    bytes.extend_from_slice(&h_vec_bytes);
+    bytes
 }
 
-impl PartialEq for VerifyingKeyData {
-    fn eq(&self, other: &Self) -> bool {
-        match self {
-        	Self::Poseidon(data) => {
-        		match other {
-        			Self::Poseidon(other_data) => {
-        				let self_gens = data.bp_gens;
-        				let other_gens = other_data.bp_gens;
+pub fn from_bytes_to_bp_gens(mut input: &[u8]) -> BulletproofGens {
+    let mut gens_capacity_bytes = [0u8; 4];
+    let _ = input.read(&mut gens_capacity_bytes);
+    let gens_capacity: usize = u32::from_be_bytes(gens_capacity_bytes) as usize;
 
-        				if self_gens.gens_capacity != other_gens.gens_capacity {
-        					return false;
-        				} else if self_gens.party_capacity != other_gens.party_capacity {
-        					return false;
-        				} else if self_gens.G_vec.len() != other_gens.G_vec.len() {
-        					return false;
-        				} else if self_gens.H_vec.len() != other_gens.H_vec.len() {
-        					return false;
-        				}
+    let mut party_capacity_bytes = [0u8; 4];
+    let _ = input.read(&mut party_capacity_bytes);
+    let party_capacity: usize = u32::from_be_bytes(party_capacity_bytes) as usize;
 
-        				true
-        			}
-        		}
-        	},
+    let mut g_vec_len_bytes = [0u8; 4];
+    let _ = input.read(&mut g_vec_len_bytes);
+    let g_vec_len: usize = u32::from_be_bytes(g_vec_len_bytes) as usize;
+    let mut g_vec = vec![0u8; g_vec_len];
+    let _ = input.read(&mut g_vec);
+    let mut g_slice = g_vec.as_slice();
+    let mut vec_of_vecs_g = vec![];
+    while g_slice.len() > 0 {
+        let mut inner_vec_len = [0u8; 4];
+        let _ = g_slice.read(&mut inner_vec_len);
+        let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len) as usize;
+        let mut inner_vec = vec![0u8; inner_vec_len_u32];
+        let _ = g_slice.read(&mut inner_vec);
+        let mut inner_g_slice = inner_vec.as_slice();
+        let mut vec_of_points = vec![];
+        while inner_g_slice.len() > 0 {
+            let mut inside_inner_g_slice = [0u8; 32];
+            let _ = inner_g_slice.read(&mut inside_inner_g_slice);
+            vec_of_points.push(CompressedRistretto(inside_inner_g_slice).decompress().unwrap());
         }
+        vec_of_vecs_g.push(vec_of_points);
     }
-}
-
-#[derive(Clone)]
-pub struct PoseidonVerifyingKey {
-	pub bp_gens: BulletproofGens,
-}
-
-// pub struct BulletproofGens {
-// 	/// The maximum number of usable generators for each party.
-// 	pub gens_capacity: usize,
-// 	/// Number of values or parties
-// 	pub party_capacity: usize,
-// 	/// Precomputed \\(\mathbf G\\) generators for each party.
-// 	G_vec: Vec<Vec<RistrettoPoint>>,
-// 	/// Precomputed \\(\mathbf H\\) generators for each party.
-// 	H_vec: Vec<Vec<RistrettoPoint>>,
-// }
-
-impl Encode for PoseidonVerifyingKey {
-	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-		let g_vec_bytes = self.bp_gens.G_vec.iter().map(|vec| {
-			vec.iter().map(|pt| pt.compress().as_bytes()).fold(vec![], |acc, curr| {
-				// inside inner len (except this should always be 32 bytes so we can drop the length)
-				// NOT_NEEDED - acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
-				// inside inner data
-				acc.append(&mut curr.to_vec());
-				acc
-			})
-		}).fold(vec![], |acc, curr| {
-			// inner len
-			acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
-			// inner data
-			acc.append(&mut curr);
-			acc
-		});
-
-		let h_vec_bytes = self.bp_gens.H_vec.iter().map(|vec| {
-			vec.iter().map(|pt| pt.compress().as_bytes()).fold(vec![], |acc, curr| {
-				// inside inner len (except this should always be 32 bytes so we can drop the length)
-				// NOT_NEEDED - acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
-				// inside inner data
-				acc.append(&mut curr.to_vec());
-				acc
-			})
-		}).fold(vec![], |acc, curr| {
-			// inner len
-			acc.append(&mut curr.to_vec().len().to_be_bytes().to_vec());
-			// inner data
-			acc.append(&mut curr);
-			acc
-		});
-
-		let bytes = vec![];
-		// bytes.extend_from_slice(&transform_u32_to_array_of_u8(self.bp_gens.gens_capacity as u32));
-		bytes.extend_from_slice(&self.bp_gens.gens_capacity.to_be_bytes());
-		bytes.extend_from_slice(&self.bp_gens.party_capacity.to_be_bytes());
-		bytes.extend_from_slice(&(g_vec_bytes.len() as u32).to_be_bytes());
-		bytes.extend_from_slice(&g_vec_bytes);
-		bytes.extend_from_slice(&(h_vec_bytes.len() as u32).to_be_bytes());
-		bytes.extend_from_slice(&h_vec_bytes);
-		bytes.using_encoded(f)
-	}
-}
-
-impl EncodeLike for PoseidonVerifyingKey {}
-
-impl Decode for PoseidonVerifyingKey {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
-		let mut gens_capacity_bytes = [0u8; 4];
-		input.read(&mut gens_capacity_bytes);
-		let gens_capacity: usize = u32::from_be_bytes(gens_capacity_bytes) as usize;
-
-		let mut party_capacity_bytes = [0u8; 4];
-		input.read(&mut party_capacity_bytes);
-		let party_capacity: usize = u32::from_be_bytes(party_capacity_bytes) as usize;
-
-		let mut g_vec_len_bytes = [0u8; 4];
-		input.read(&mut g_vec_len_bytes);
-		let g_vec_len: usize = u32::from_be_bytes(g_vec_len_bytes) as usize;
-
-		let g_vec = Vec::with_capacity(g_vec_len);
-		input.read(&mut g_vec);
-		let mut g_slice = g_vec.as_slice();
-		let vec_of_vecs_g = vec![];
-		while g_slice.len() > 0 {
-			let inner_vec_len = [0u8; 4];
-			g_slice.read(&mut inner_vec_len);
-			let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len);
-			let inner_vec = Vec::with_capacity(g_vec_len);
-			g_slice.read(&mut inner_vec);
-			let mut inner_g_slice = inner_vec.as_slice();
-			let vec_of_points = vec![];
-			while inner_g_slice.len() > 0 {
-				let mut inside_inner_g_slice = [0u8; 32];
-				inner_g_slice.read(&mut inside_inner_g_slice);
-				vec_of_points.push(CompressedRistretto(inside_inner_g_slice).decompress().unwrap());
-			}
-			vec_of_vecs_g.push(vec_of_points);
-		}
 
 
-		let mut h_vec_len_bytes = [0u8; 4];
-		input.read(&mut g_vec_len_bytes);
-		let h_vec_len: usize = u32::from_be_bytes(g_vec_len_bytes) as usize;
-
-		let h_vec = Vec::with_capacity(h_vec_len);
-		input.read(&mut h_vec);
-		let mut h_slice = h_vec.as_slice();
-		let vec_of_vecs_h = vec![];
-		while h_slice.len() > 0 {
-			let inner_vec_len = [0u8; 4];
-			h_slice.read(&mut inner_vec_len);
-			let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len);
-			let inner_vec = Vec::with_capacity(h_vec_len);
-			h_slice.read(&mut inner_vec);
-			let mut inner_h_slice = inner_vec.as_slice();
-			let vec_of_points = vec![];
-			while inner_h_slice.len() > 0 {
-				let mut inside_inner_h_slice = [0u8; 32];
-				inner_h_slice.read(&mut inside_inner_h_slice);
-				vec_of_points.push(CompressedRistretto(inside_inner_h_slice).decompress().unwrap());
-			}
-			vec_of_vecs_h.push(vec_of_points);
-		}
-		
-		Ok(PoseidonVerifyingKey {
-			bp_gens: BulletproofGens {
-				gens_capacity,
-				party_capacity, 
-				G_vec: vec_of_vecs_g,
-				H_vec: vec_of_vecs_h,
-			}
-		})
-	}
+    let mut h_vec_len_bytes = [0u8; 4];
+    let _ = input.read(&mut h_vec_len_bytes);
+    let h_vec_len: usize = u32::from_be_bytes(h_vec_len_bytes) as usize;
+    let mut h_vec = vec![0u8; h_vec_len];
+    let _ = input.read(&mut h_vec);
+    let mut h_slice = h_vec.as_slice();
+    let mut vec_of_vecs_h = vec![];
+    while h_slice.len() > 0 {
+        let mut inner_vec_len = [0u8; 4];
+        let _ = h_slice.read(&mut inner_vec_len);
+        let inner_vec_len_u32 = u32::from_be_bytes(inner_vec_len) as usize;
+        let mut inner_vec = vec![0u8; inner_vec_len_u32];
+        let _ = h_slice.read(&mut inner_vec);
+        let mut inner_h_slice = inner_vec.as_slice();
+        let mut vec_of_points = vec![];
+        while inner_h_slice.len() > 0 {
+            let mut inside_inner_h_slice = [0u8; 32];
+            let _ = inner_h_slice.read(&mut inside_inner_h_slice);
+            vec_of_points.push(CompressedRistretto(inside_inner_h_slice).decompress().unwrap());
+        }
+        vec_of_vecs_h.push(vec_of_points);
+    }
+    
+    BulletproofGens {
+        gens_capacity,
+        party_capacity, 
+        G_vec: vec_of_vecs_g,
+        H_vec: vec_of_vecs_h,
+    }
 }

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -31,12 +31,16 @@ webb-currencies = { default-features = false, path = "../currencies" }
 [dependencies.bulletproofs]
 version = "2.0.0"
 package = "webb-bulletproofs"
+git = "https://github.com/webb-tools/bulletproofs"
+branch = "pub-bp-gens"
 default-features = false
 features = ["yoloproofs"]
 
 [dependencies.bulletproofs-gadgets]
 version = "2.0.0"
 default-features = false
+git = "https://github.com/webb-tools/bulletproof-gadgets"
+branch = "bulletproofs-codec"
 
 [dependencies.curve25519-dalek]
 version = "3.0.0"

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -53,6 +53,7 @@ version = "0.1.5"
 [dev-dependencies]
 sp-core = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
 sp-io = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
+pallet-randomness-collective-flip = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4" }
 
 [features]
 default = ["std"]

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -21,7 +21,6 @@ sp-runtime = { default-features = false, version = "3.0.0", git = "https://githu
 merkle = { package = "pallet-merkle", path = "../merkle", default-features = false }
 webb-tokens = { path = "../tokens", default-features = false }
 
-
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 merlin = { version = "2.0.0", default-features = false }
 frame-benchmarking = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.4", optional = true }
@@ -29,15 +28,14 @@ webb-traits = { default-features = false, path = "../traits" }
 webb-currencies = { default-features = false, path = "../currencies" }
 
 [dependencies.bulletproofs]
-version = "2.0.0"
+version = "2.0.3"
 package = "webb-bulletproofs"
 git = "https://github.com/webb-tools/bulletproofs"
-branch = "pub-bp-gens"
 default-features = false
 features = ["yoloproofs"]
 
 [dependencies.bulletproofs-gadgets]
-version = "2.0.0"
+version = "2.1.1"
 default-features = false
 git = "https://github.com/webb-tools/bulletproof-gadgets"
 branch = "bulletproofs-codec"
@@ -64,6 +62,8 @@ std = [
     "frame-support/std",
     "frame-system/std",
     "webb-tokens/std",
+    "bulletproofs/std",
+    "bulletproofs-gadgets/std",
     "frame-benchmarking/std",
     "merkle/std",
 ]

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -30,15 +30,12 @@ webb-currencies = { default-features = false, path = "../currencies" }
 [dependencies.bulletproofs]
 version = "2.0.3"
 package = "webb-bulletproofs"
-git = "https://github.com/webb-tools/bulletproofs"
 default-features = false
 features = ["yoloproofs"]
 
 [dependencies.bulletproofs-gadgets]
 version = "2.1.1"
 default-features = false
-git = "https://github.com/webb-tools/bulletproof-gadgets"
-branch = "bulletproofs-codec"
 
 [dependencies.curve25519-dalek]
 version = "3.0.0"

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -57,13 +57,12 @@ pub mod weights;
 pub mod traits;
 
 use bulletproofs::BulletproofGens;
-use merkle::utils::keys::get_bp_gen_bytes;
 use codec::{Decode, Encode};
 use frame_support::{dispatch, ensure, traits::Get, weights::Weight, PalletId};
 use frame_system::ensure_signed;
 use merkle::{
 	utils::{
-		keys::{Commitment, ScalarData},
+		keys::{get_bp_gen_bytes, Commitment, ScalarData},
 		permissions::ensure_admin,
 	},
 	Pallet as MerklePallet, Tree as TreeTrait,
@@ -212,7 +211,7 @@ pub mod pallet {
 					if let Ok(initialized) = T::Tree::is_initialized(mixer_ids[i]) {
 						if !initialized {
 							match Self::initialize_mixer_trees() {
-								Ok(_) => {},
+								Ok(_) => {}
 								Err(e) => {
 									log::error!("Error initialising trees: {:?}", e);
 								}
@@ -530,7 +529,8 @@ impl<T: Config> Pallet<T> {
 
 	pub fn get_mixer(mixer_id: T::TreeId) -> Result<MixerInfo<T>, dispatch::DispatchError> {
 		let mixer_info = MixerTrees::<T>::get(mixer_id);
-		// ensure mixer_info has a non-zero deposit, otherwise, the mixer doesn't exist for this id
+		// ensure mixer_info has a non-zero deposit, otherwise, the mixer doesn't exist
+		// for this id
 		ensure!(mixer_info.fixed_deposit_size > Zero::zero(), Error::<T>::NoMixerForId);
 		// ensure the mixer's tree is intialized
 		let initialized = T::Tree::is_initialized(mixer_id)?;

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type NativeCurrencyId: Get<CurrencyIdOf<Self>>;
 		/// The overarching merkle tree trait
-		type Tree: TreeTrait<Self::AccountId, Self::BlockNumber, Self::TreeId>;
+		type Tree: TreeTrait<Self>;
 		/// The small deposit length
 		#[pallet::constant]
 		type DepositLength: Get<Self::BlockNumber>;
@@ -342,7 +342,7 @@ pub mod pallet {
 			ensure_admin(origin, &Self::admin())?;
 
 			let depth: u8 = <T as merkle::Config>::MaxTreeDepth::get();
-			let mixer_id: T::TreeId = T::Tree::create_tree(Self::account_id(), true, depth)?;
+			let mixer_id: T::TreeId = T::Tree::create_tree(Self::account_id(), true, depth, true)?;
 			let mixer_info = MixerInfo::<T>::new(T::DepositLength::get(), size, currency_id);
 			MixerTrees::<T>::insert(mixer_id, mixer_info);
 
@@ -522,7 +522,7 @@ impl<T: Config> Pallet<T> {
 		// Iterating over configured sizes and initializing the mixers
 		for size in sizes.into_iter() {
 			// Creating a new merkle group and getting the id back
-			let mixer_id: T::TreeId = T::Tree::create_tree(Self::account_id(), true, depth)?;
+			let mixer_id: T::TreeId = T::Tree::create_tree(Self::account_id(), true, depth, true)?;
 			// Creating mixer info data
 			let mixer_info = MixerInfo::<T>::new(T::DepositLength::get(), size, T::NativeCurrencyId::get());
 			// Saving the mixer group to storage
@@ -545,7 +545,7 @@ impl<T: Config> ExtendedMixer<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>> for P
 		size: BalanceOf<T>,
 	) -> Result<(), dispatch::DispatchError> {
 		let depth: u8 = <T as merkle::Config>::MaxTreeDepth::get();
-		let mixer_id: T::TreeId = T::Tree::create_tree(Self::account_id(), true, depth)?;
+		let mixer_id: T::TreeId = T::Tree::create_tree(Self::account_id(), true, depth, true)?;
 		let mixer_info = MixerInfo::<T>::new(T::DepositLength::get(), size, currency_id);
 		MixerTrees::<T>::insert(mixer_id, mixer_info);
 		Ok(())

--- a/pallets/mixer/src/mock.rs
+++ b/pallets/mixer/src/mock.rs
@@ -140,6 +140,7 @@ impl merkle::Config for Test {
 	type Event = Event;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
+	type KeyId = u32;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/pallets/mixer/src/mock.rs
+++ b/pallets/mixer/src/mock.rs
@@ -138,9 +138,9 @@ impl webb_currencies::Config for Test {
 impl merkle::Config for Test {
 	type CacheBlockLength = CacheBlockLength;
 	type Event = Event;
+	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
-	type KeyId = u32;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/pallets/mixer/src/mock.rs
+++ b/pallets/mixer/src/mock.rs
@@ -141,8 +141,8 @@ impl merkle::Config for Test {
 	type Event = Event;
 	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
-	type TreeId = u32;
 	type Randomness = Randomness;
+	type TreeId = u32;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/pallets/mixer/src/mock.rs
+++ b/pallets/mixer/src/mock.rs
@@ -36,6 +36,7 @@ construct_runtime!(
 		Mixer: pallet_mixer::{Pallet, Call, Storage, Event<T>},
 		Currencies: webb_currencies::{Pallet, Storage, Event<T>},
 		Tokens: webb_tokens::{Pallet, Storage, Event<T>},
+		Randomness: pallet_randomness_collective_flip::{Pallet, Call, Storage},
 	}
 );
 
@@ -141,6 +142,7 @@ impl merkle::Config for Test {
 	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
+	type Randomness = Randomness;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -3,9 +3,7 @@ use crate::mock::{
 	new_test_ext, AccountId, Balance, Balances, CurrencyId, MerkleTrees, Mixer, MixerCall, Origin, System, Test, Tokens,
 };
 use bulletproofs::{r1cs::Prover, BulletproofGens, PedersenGens};
-use bulletproofs_gadgets::{
-	fixed_deposit_tree::builder::FixedDepositTreeBuilder,
-};
+use bulletproofs_gadgets::fixed_deposit_tree::builder::FixedDepositTreeBuilder;
 use curve25519_dalek::scalar::Scalar;
 use frame_support::{
 	assert_err, assert_ok,

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -1,4 +1,3 @@
-use merkle::utils::keys::get_bp_gen_bytes;
 use super::*;
 use crate::mock::{
 	new_test_ext, AccountId, Balance, Balances, CurrencyId, MerkleTrees, Mixer, MixerCall, Origin, System, Test, Tokens,
@@ -18,7 +17,7 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 use merkle::{
-	utils::keys::{Commitment, ScalarData},
+	utils::keys::{get_bp_gen_bytes, Commitment, ScalarData},
 	HighestCachedBlock,
 };
 use merlin::Transcript;
@@ -375,7 +374,11 @@ fn should_make_mixer_with_non_native_token() {
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
 		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
 		let key_id = 0;
-		assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
+		assert_ok!(MerkleTrees::initialize_tree(
+			Origin::signed(Mixer::account_id()),
+			tree_id,
+			key_id
+		));
 
 		let poseidon = MerkleTrees::get_poseidon_hasher_for_tree(tree_id).unwrap();
 

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -55,6 +55,7 @@ fn should_initialize_successfully() {
 fn should_initialize_successfully_on_finalize() {
 	new_test_ext().execute_with(|| {
 		<Mixer as OnFinalize<u64>>::on_finalize(1);
+		<Mixer as OnFinalize<u64>>::on_finalize(2);
 		// the mixer creates 4 groups, they should all initialise to 0
 		let val = 1_000;
 		for i in 0..4 {

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -358,7 +358,7 @@ fn should_make_mixer_with_non_native_token() {
 
 		let tree_id = 4u32;
 		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
+		assert_ok!(MerkleTrees::add_verifying_key(Origin::root(), key_data));
 		let key_id = 0;
 		assert_ok!(MerkleTrees::initialize_tree(
 			Origin::signed(Mixer::account_id()),

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -37,6 +37,7 @@ fn default_hasher(num_gens: usize) -> Poseidon {
 fn should_initialize_successfully() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		// the mixer creates 4 groups, they should all initialise to 0
 		let val = 1_000;
 		for i in 0..4 {
@@ -86,6 +87,7 @@ fn should_be_able_to_change_admin_with_root() {
 fn should_be_able_to_stop_mixers_with_root() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let call = Box::new(MixerCall::set_stopped(true));
 		let res = call.dispatch_bypass_filter(RawOrigin::Root.into());
 		assert_ok!(res);
@@ -102,6 +104,7 @@ fn should_be_able_to_change_admin() {
 	new_test_ext().execute_with(|| {
 		let default_admin = 4;
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		assert_err!(Mixer::transfer_admin(Origin::signed(1), 2), BadOrigin);
 		assert_ok!(Mixer::transfer_admin(Origin::signed(default_admin), 2));
 		let admin = Mixer::admin();
@@ -115,15 +118,8 @@ fn should_stop_and_start_mixer() {
 	new_test_ext().execute_with(|| {
 		let default_admin = 4;
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let mut tree = FixedDepositTreeBuilder::new().build();
-
-		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
-		let key_id = 0;
-		for i in 0..4 {
-			let tree_id = i;
-			assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
-		}
 
 		let leaf = tree.generate_secrets();
 		assert_ok!(Mixer::deposit(Origin::signed(0), 0, vec![ScalarData(leaf)]));
@@ -164,15 +160,8 @@ fn should_stop_and_start_mixer() {
 fn should_fail_to_deposit_with_insufficient_balance() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let mut tree = FixedDepositTreeBuilder::new().build();
-
-		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
-		let key_id = 0;
-		for i in 0..4 {
-			let tree_id = i;
-			assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
-		}
 
 		for i in 0..4 {
 			let leaf = tree.generate_secrets();
@@ -192,15 +181,8 @@ fn should_fail_to_deposit_with_insufficient_balance() {
 fn should_deposit_into_each_mixer_successfully() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let mut tree = FixedDepositTreeBuilder::new().build();
-
-		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
-		let key_id = 0;
-		for i in 0..4 {
-			let tree_id = i;
-			assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
-		}
 
 		for i in 0..4 {
 			let leaf = tree.generate_secrets();
@@ -223,15 +205,8 @@ fn should_deposit_into_each_mixer_successfully() {
 fn should_withdraw_from_each_mixer_successfully() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let pc_gens = PedersenGens::default();
-
-		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
-		let key_id = 0;
-		for i in 0..4 {
-			let tree_id = i;
-			assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
-		}
 
 		for i in 0..4 {
 			let tree_id = i;
@@ -297,16 +272,9 @@ fn should_cache_roots_if_no_new_deposits_show() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let mut tree = FixedDepositTreeBuilder::new().build();
 		let mut merkle_roots: Vec<ScalarData> = vec![];
-
-		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
-		let key_id = 0;
-		for i in 0..4 {
-			let tree_id = i;
-			assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
-		}
 
 		for i in 0..4 {
 			let leaf = tree.generate_secrets();
@@ -340,16 +308,9 @@ fn should_not_have_cache_once_cache_length_exceeded() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		let mut tree = FixedDepositTreeBuilder::new().build();
 		let mut merkle_roots: Vec<ScalarData> = vec![];
-
-		let key_data = get_bp_gen_bytes(&BulletproofGens::new(16400, 1));
-		assert_ok!(MerkleTrees::add_verifying_key(Origin::signed(1), key_data));
-		let key_id = 0;
-		for i in 0..4 {
-			let tree_id = i;
-			assert_ok!(MerkleTrees::initialize_tree(Origin::signed(Mixer::account_id()), tree_id, key_id));
-		}
 
 		for i in 0..4 {
 			let leaf = tree.generate_secrets();
@@ -400,6 +361,7 @@ fn should_make_mixer_with_non_native_token() {
 			1, 0, 10000000
 		));
 		assert_ok!(Mixer::initialize());
+		assert_ok!(Mixer::initialize_mixer_trees());
 		assert_ok!(<Mixer as ExtendedMixer<AccountId, CurrencyId, Balance>>::create_new(
 			1,
 			currency_id,
@@ -480,4 +442,29 @@ fn should_make_mixer_with_non_native_token() {
 		let tvl = Mixer::total_value_locked(tree_id);
 		assert_eq!(tvl, 0);
 	});
+}
+
+#[test]
+fn should_initialize_in_two_steps_on_finalize() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		<Mixer as OnFinalize<u64>>::on_finalize(1);
+		assert!(Mixer::first_stage_initialized());
+
+		for i in 0..4 {
+			let tree_id = i;
+			let tree = MerkleTrees::get_tree(tree_id).unwrap();
+			assert!(!tree.initialized);
+		}
+
+		System::set_block_number(2);
+		<Mixer as OnFinalize<u64>>::on_finalize(2);
+		assert!(Mixer::second_stage_initialized());
+
+		for i in 0..4 {
+			let tree_id = i;
+			let tree = MerkleTrees::get_tree(tree_id).unwrap();
+			assert!(tree.initialized);
+		}
+	})
 }

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -5,10 +5,6 @@ use crate::mock::{
 use bulletproofs::{r1cs::Prover, BulletproofGens, PedersenGens};
 use bulletproofs_gadgets::{
 	fixed_deposit_tree::builder::FixedDepositTreeBuilder,
-	poseidon::{
-		builder::{Poseidon, PoseidonBuilder},
-		PoseidonSbox,
-	},
 };
 use curve25519_dalek::scalar::Scalar;
 use frame_support::{
@@ -23,14 +19,6 @@ use merkle::{
 use merlin::Transcript;
 use sp_runtime::{traits::BadOrigin, DispatchError};
 use webb_tokens::ExtendedTokenSystem;
-
-fn default_hasher(num_gens: usize) -> Poseidon {
-	let width = 6;
-	PoseidonBuilder::new(width)
-		.bulletproof_gens(BulletproofGens::new(num_gens, 1))
-		.sbox(PoseidonSbox::Exponentiation3)
-		.build()
-}
 
 #[test]
 fn should_initialize_successfully() {
@@ -362,8 +350,8 @@ fn should_make_mixer_with_non_native_token() {
 		));
 		assert_ok!(Mixer::initialize());
 		assert_ok!(Mixer::initialize_mixer_trees());
-		assert_ok!(<Mixer as ExtendedMixer<AccountId, CurrencyId, Balance>>::create_new(
-			1,
+		assert_ok!(<Mixer as ExtendedMixer<Test>>::create_new(
+			Mixer::account_id(),
 			currency_id,
 			1_000
 		));

--- a/pallets/mixer/src/traits.rs
+++ b/pallets/mixer/src/traits.rs
@@ -2,6 +2,9 @@ use super::*;
 use frame_support::dispatch;
 
 pub trait ExtendedMixer<T: Config> {
-	fn create_new(account_id: T::AccountId, currency_id: CurrencyIdOf<T>, size: BalanceOf<T>)
-		-> Result<T::TreeId, dispatch::DispatchError>;
+	fn create_new(
+		account_id: T::AccountId,
+		currency_id: CurrencyIdOf<T>,
+		size: BalanceOf<T>,
+	) -> Result<T::TreeId, dispatch::DispatchError>;
 }

--- a/pallets/mixer/src/traits.rs
+++ b/pallets/mixer/src/traits.rs
@@ -1,6 +1,7 @@
+use super::*;
 use frame_support::dispatch;
 
-pub trait ExtendedMixer<AccountId, CurrencyId, Balance> {
-	fn create_new(account_id: AccountId, currency_id: CurrencyId, size: Balance)
-		-> Result<(), dispatch::DispatchError>;
+pub trait ExtendedMixer<T: Config> {
+	fn create_new(account_id: T::AccountId, currency_id: CurrencyIdOf<T>, size: BalanceOf<T>)
+		-> Result<T::TreeId, dispatch::DispatchError>;
 }

--- a/pallets/tokens/src/lib.rs
+++ b/pallets/tokens/src/lib.rs
@@ -33,13 +33,13 @@ use sp_std::{
 };
 
 use codec::{Decode, Encode};
-use frame_support::pallet_prelude::*;
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	ensure, log,
+	pallet_prelude::*,
 	traits::{
 		Currency as PalletCurrency, ExistenceRequirement, Get, Imbalance, LockableCurrency as PalletLockableCurrency,
-		ReservableCurrency as PalletReservableCurrency, SignedImbalance, WithdrawReasons, 
+		ReservableCurrency as PalletReservableCurrency, SignedImbalance, WithdrawReasons,
 	},
 	transactional, PalletId,
 };
@@ -152,7 +152,13 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// The balance type
-		type Balance: Parameter + Member + AtLeast32BitUnsigned + Default + Copy + MaybeSerializeDeserialize + MaxEncodedLen;
+		type Balance: Parameter
+			+ Member
+			+ AtLeast32BitUnsigned
+			+ Default
+			+ Copy
+			+ MaybeSerializeDeserialize
+			+ MaxEncodedLen;
 
 		/// The amount type, should be signed version of `Balance`
 		type Amount: Signed

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -353,8 +353,8 @@ impl merkle::Config for Runtime {
 	type Event = Event;
 	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
-	type TreeId = u32;
 	type Randomness = RandomnessCollectiveFlip;
+	type TreeId = u32;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -353,6 +353,7 @@ impl merkle::Config for Runtime {
 	type Event = Event;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
+	type KeyId = u32;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -303,25 +303,25 @@ parameter_types! {
 }
 
 impl pallet_contracts::Config for Runtime {
-	type Time = Timestamp;
-	type Randomness = RandomnessCollectiveFlip;
+	type CallStack = [pallet_contracts::Frame<Self>; 31];
+	type ChainExtension = ();
 	type Currency = Balances;
-	type Event = Event;
-	type RentPayment = ();
-	type SignedClaimHandicap = SignedClaimHandicap;
-	type TombstoneDeposit = TombstoneDeposit;
+	type DeletionQueueDepth = DeletionQueueDepth;
+	type DeletionWeightLimit = DeletionWeightLimit;
 	type DepositPerContract = DepositPerContract;
 	type DepositPerStorageByte = DepositPerStorageByte;
 	type DepositPerStorageItem = DepositPerStorageItem;
+	type Event = Event;
+	type Randomness = RandomnessCollectiveFlip;
 	type RentFraction = RentFraction;
-	type SurchargeReward = SurchargeReward;
-	type CallStack = [pallet_contracts::Frame<Self>; 31];
-	type WeightPrice = pallet_transaction_payment::Module<Self>;
-	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
-	type ChainExtension = ();
-	type DeletionQueueDepth = DeletionQueueDepth;
-	type DeletionWeightLimit = DeletionWeightLimit;
+	type RentPayment = ();
 	type Schedule = Schedule;
+	type SignedClaimHandicap = SignedClaimHandicap;
+	type SurchargeReward = SurchargeReward;
+	type Time = Timestamp;
+	type TombstoneDeposit = TombstoneDeposit;
+	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
+	type WeightPrice = pallet_transaction_payment::Module<Self>;
 }
 
 parameter_types! {
@@ -351,9 +351,9 @@ parameter_types! {
 impl merkle::Config for Runtime {
 	type CacheBlockLength = CacheBlockLength;
 	type Event = Event;
+	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
-	type KeyId = u32;
 	type WeightInfo = MerkleWeights<Self>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -354,6 +354,7 @@ impl merkle::Config for Runtime {
 	type KeyId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type TreeId = u32;
+	type Randomness = RandomnessCollectiveFlip;
 	type WeightInfo = MerkleWeights<Self>;
 }
 


### PR DESCRIPTION
# Overview
This update takes the parameters out of the runtime binary and instead uses a two-stage intialization for mixers / merkle trees to add parameters to the runtime storage. Merkle trees now have an initialized state that is set once a user sets the respective keys necessary for hashing as well as initializes the state of the tree with the zero hashed state.

Bulletproof parameters are now stored directly in runtime storage as well and the two-stage initialization takes place in `on_finalize` of the mixer pallet. This is so we don't have to store the parameters in the runtime binary directly to allow us to hopefully make our runtime smaller for a potential Hedgeware initial release.

# Note
This adds new functionality to the pallets which deviate from Edgeware's ERUP-4 implementation. Therefore, we may want to consider a runtime migration for Edgeware related trees.

Nonetheless this functionality is more a glimpse of how we should begin designing `darkwebb` with more friendly parameter initialization for our hashers and verifiers.